### PR TITLE
fix: auto_doc_ref and undefined label

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -105,8 +105,7 @@ pygments_style = 'sphinx'
 def setup(app):
     app.add_config_value('recommonmark_config', {
         'auto_toc_tree_section': 'Contents',
-        'enable_eval_rst': True,
-        'enable_auto_doc_ref': True
+        'enable_eval_rst': True
     }, True)
     app.add_transform(AutoStructify)
 

--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -105,8 +105,7 @@ pygments_style = 'sphinx'
 def setup(app):
     app.add_config_value('recommonmark_config', {
         'auto_toc_tree_section': 'Contents',
-        'enable_eval_rst': True,
-        'enable_auto_doc_ref': True
+        'enable_eval_rst': True
     }, True)
     app.add_transform(AutoStructify)
 

--- a/docs/it/conf.py
+++ b/docs/it/conf.py
@@ -105,8 +105,7 @@ pygments_style = 'sphinx'
 def setup(app):
     app.add_config_value('recommonmark_config', {
         'auto_toc_tree_section': 'Contents',
-        'enable_eval_rst': True,
-        'enable_auto_doc_ref': True
+        'enable_eval_rst': True
     }, True)
     app.add_transform(AutoStructify)
 

--- a/docs/it/la_federazione_delle_identita.rst
+++ b/docs/it/la_federazione_delle_identita.rst
@@ -10,7 +10,7 @@ Affinché i partecipanti, siano essi RP o OP, si riconoscano all’interno della
 
 I metadati sono certificati da un parte fidata che all’interno della Federazione SPID è AgID, mentre all'interno della Federazione CIE è il Ministero dell'Interno. Questi corrispondono alla Autorità di Federazione.
 
-SPID e CIE id implementano OpenID Connect Federation 1.0 e ne estendono alcune funzionalità, realizzano una implementazione concreta e producono le buone pratiche per la sua adozione. Per approfondimenti allo standard si rimanda alle specifiche ufficiali `OIDC-FED`_ e alla sezione :ref:`Differenze con OIDC Federation 1.0<differenze_con_oidc_federation_1.0>`. 
+SPID e CIE id implementano OpenID Connect Federation 1.0 e ne estendono alcune funzionalità, realizzano una implementazione concreta e producono le buone pratiche per la sua adozione. Per approfondimenti allo standard si rimanda alle specifiche ufficiali `OIDC-FED`_ e alla sezione :ref:`Differenze con OIDC Federation 1.0<differenze_con_oidc_federation>`. 
 
 
 Perché OIDC Federation

--- a/docs/it/trust_negotiation.rst
+++ b/docs/it/trust_negotiation.rst
@@ -9,7 +9,7 @@ In questa sezione vi sono illustrate le modalità di mutuo riconoscimento tra RP
 Relying Party
 +++++++++++++
 
-Il RP ottiene la lista degli OP in formato JSON interrogando l’:ref:`endpoint list<Entity_Listing_endpoint>` disponibile presso il :ref:`Trust Anchor<Esempio_EN3>`. Per ogni soggetto contenuto nella :ref:`risposta<Esempio_EN3.1>` dell’endpoint list e corrispondente ad un OP, il RP :ref:`richiede<Esempio_EN2>` ed ottiene l’Entity Configuration self-signed presso l’OP. 
+Il RP ottiene la lista degli OP in formato JSON interrogando l’:ref:`endpoint list<entity_listings>` disponibile presso il :ref:`Trust Anchor<Esempio_EN3>`. Per ogni soggetto contenuto nella :ref:`risposta<Esempio_EN3.1>` dell’endpoint list e corrispondente ad un OP, il RP :ref:`richiede<Esempio_EN2>` ed ottiene l’Entity Configuration self-signed presso l’OP. 
 
 Per ogni EC degli OP, il RP verifica la firma del contenuto adoperando la chiave pubblica ottenuta dall’Entity Statement rilasciato dalla Trust Anchor. Verificata la firma dell’Entity Configuration con la chiave pubblica pubblicata dalla Trust Anchor la fiducia è stabilita nei confronti del OP da parte del RP. 
 


### PR DESCRIPTION
## Title
Fix warning enable_auto_doc_ref and undefined label
## Content
- enable_auto_doc_ref: 
This option is deprecated. This option has been superseded by the default linking behavior, which will first try to resolve as an internal reference, and then as an external reference.
https://recommonmark.readthedocs.io/en/latest/auto_structify.html#auto-doc-ref

- undefined label:
In section "Le Federazioni eID Italiane" fix the ref to Differenze con OIDC Federation 1.0
In section "Trust negotiation" fix the ref to endpoint list

## Review

- [ ] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [ ] English version
- [ ] Example files 
- [ ] Ask for review
