### PR TITLE
fix: [Core] user attribute gender as oidc ore specs

### DIFF
--- a/docs/en/attributi_utente.rst
+++ b/docs/en/attributi_utente.rst
@@ -89,13 +89,13 @@ User attributes
      - |spid-icon| |cieid-icon|
    * - **gender**
      - Gender. String. Values accepted: |br|
-       "F" for female |br|
-       "M" for male |br|
+       "female" for female |br|
+       "male" for male |br|
        Example: |br|
 
        .. code-block:: json
 
-         "gender": "F"
+         "gender": "male"
 
      - |spid-icon| |cieid-icon|
    * - **https://attributes.eid.gov.it/company_name**

--- a/docs/it/attributi_utente.rst
+++ b/docs/it/attributi_utente.rst
@@ -84,13 +84,13 @@ Tabella attributi utente
      - |spid-icon| |cieid-icon|
    * - **gender**
      - Sesso (anagrafica). String. Valori ammessi: |br|
-       "F" per sesso femminile |br|
-       "M" per sesso maschile |br|
+       "female" per sesso femminile |br|
+       "male" per sesso maschile |br|
        Esempio: |br|
 
        .. code-block:: json
 
-         "gender":"F"
+         "gender":"female"
 
      - |spid-icon| |cieid-icon|
    * - **https://attributes.eid.gov.it/company_name**


### PR DESCRIPTION
Closes https://github.com/italia/spid-cie-oidc-docs/issues/59

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [x] Example files 
- [x] Ask for review
