### PR TITLE
fix: alignments to DRAFT 25 and small editorials

### DIFF
--- a/docs/common/common_examples.rst
+++ b/docs/common/common_examples.rst
@@ -689,14 +689,13 @@ EN 5. Trust Mark Status Request
 
 .. code-block:: http
 
- GET /trust_mark_status/?
- id=https://registry.agid.gov.it/openid_relying_party/public/
- &sub=https://rp.example.it/ 
- 
- HTTP/1.1
+ POST /trust_mark_status HTTP/1.1
  Host: registry.agid.gov.it
-
-
+ Content-Type: application/x-www-form-urlencoded
+ 
+ id=https%3A%2F%2registry.agid.gov.it%2Fopenid_relying_party%2Fpublic%2F
+ &sub=https%3A%2F%2rp.example.it%2F
+ 
 
 EN 5.1. Trust Mark Status Response
 ++++++++++++++++++++++++++++++++++

--- a/docs/en/differenze_oidc_fed.rst
+++ b/docs/en/differenze_oidc_fed.rst
@@ -14,16 +14,10 @@ Client Registration
 SPID supports only **automatic_client_registration**. The **implicit** flow is not supported.
 
 
-Listing endpoint
-++++++++++++++++
-
-In the SPID / CIE Federations, for this endpoint, the claim **entity_type** is added to all the other `OIDC-FED`_ standard claims, in order to obtain a filter on the type of subordinate Entities. This need apecifically allows filtering Entities of type **federation_entity**, **openid_relying_party**, **openid_provider** and **oauth_resource**.
-
-
 Trust Mark
 ++++++++++
 
-In the SPID and CIE id Federations, using Trust Marks is not mandatory. Rather, in the SPID Federation it is mandatory to expose them. For more details about the reasons why the Trust Marks are required, please see the section :ref:`Security Considerations <Considerazioni_di_Sicurezza>`.
+In OIDC Federation international specifications the adoption of the Trust Marks are not mandatory. Rather, in the SPID and CIE id Federation it is mandatory to expose them. For more details about the reasons why the Trust Marks are required, please see the section :ref:`Security Considerations <Considerazioni_di_Sicurezza>`.
 
 
 Unsupported Claims in the Entity Statements

--- a/docs/en/differenze_oidc_fed.rst
+++ b/docs/en/differenze_oidc_fed.rst
@@ -11,7 +11,7 @@ This section lists the differences between the official standard and the SPID / 
 Client Registration
 +++++++++++++++++++
 
-SPID and CIE support only **automatic_client_registration**. The **implicit** flow is not supported.
+SPID and CIE support only **automatic_client_registration**. The **explicit client registration** flow is not supported.
 
 
 Trust Mark

--- a/docs/en/differenze_oidc_fed.rst
+++ b/docs/en/differenze_oidc_fed.rst
@@ -17,7 +17,7 @@ SPID and CIE support only **automatic_client_registration**. The **explicit clie
 Trust Mark
 ++++++++++
 
-In OIDC Federation international specifications the adoption of the Trust Marks are not mandatory. Rather, in the SPID and CIE id Federation it is mandatory to expose them. For more details about the reasons why the Trust Marks are required, please see the section :ref:`Security Considerations <Considerazioni_di_Sicurezza>`.
+In OIDC Federation international specifications the adoption of the Trust Marks is not mandatory. Rather, in the SPID and CIE Federation it is mandatory to expose them. For more details about the reasons why the Trust Marks are required, please see the section :ref:`Security Considerations <Considerazioni_di_Sicurezza>`.
 
 
 Unsupported Claims in the Entity Statements

--- a/docs/en/differenze_oidc_fed.rst
+++ b/docs/en/differenze_oidc_fed.rst
@@ -11,7 +11,7 @@ This section lists the differences between the official standard and the SPID / 
 Client Registration
 +++++++++++++++++++
 
-SPID supports only **automatic_client_registration**. The **implicit** flow is not supported.
+SPID and CIE support only **automatic_client_registration**. The **implicit** flow is not supported.
 
 
 Trust Mark

--- a/docs/en/federation_endpoint.rst
+++ b/docs/en/federation_endpoint.rst
@@ -29,8 +29,3 @@ In addition to the Federation endpoints reported before, the Entities of type **
    (For more details, see `OIDC-FED`_ Section 7.3).
 
 An Entity of type **AA**, in addition to the common Federation endpoints like all the Entities, MUST also include the **trust mark status endpoint** for allowing the dynamic validation of the TMs, released by the AA.
-
-
-.. warning::
-  As defined in the OIDC-FED, to the **Entity listing endpoint** is added the optional claim **entity_type**, that is a filter of the Entity type of the subordinates.
-

--- a/docs/en/federation_endpoint.rst
+++ b/docs/en/federation_endpoint.rst
@@ -23,7 +23,7 @@ In addition to the Federation endpoints reported before, the Entities of type **
 
  - **fetch Entity statement endpoint**: returns the ESs regarding a direct subordinate subject. 
    For obtaining the ES of an Entity, at least its Entity identifier is needed. (For more details, see `OIDC-FED`_ Section 7.1).
- - **trust mark status endpoint**: allows an Entity to test if a TM is still active or not. The query MUST
+ - **trust mark status endpoint**: allows an Entity to test if a TM is still active or not. The request MUST
    be sent to the subject that has released that TM. (For more details, see `OIDC-FED`_ Section 7.4).
  - **Entity listing endpoint**: returns the list of the subordinate Entities registered by the TA or an SA.
    (For more details, see `OIDC-FED`_ Section 7.3).

--- a/docs/en/seccons_bcps.rst
+++ b/docs/en/seccons_bcps.rst
@@ -59,12 +59,3 @@ The interoperability among members works through the Metadata obtained from the 
 A best practice to avoid service stops on the OIDC Core operations, is adding the new public keys inside the objects *jwks* without removing the previous values. Or, for example, the new *redirect_uri*.
 
 In this way, after exceeding the maximum duration limit of the Trust Chain, defined in the claim **exp** and published in the TA Entity Configuration, it is certain that all the members have renewed their Trust Chain and it is possible, for the Leaf administrators, to remove the old definitions from the top of the list.
-
-
-
-Metadata Policy
-+++++++++++++++
-
-The Federation Authority or its Intermediary MAY publish a Metadata policy (see `OIDC-FED`_ Section 5.1) 
-to force the change of the OIDC Metadata of the Leaf, in the parts where this might be needed.
-

--- a/docs/en/seccons_bcps.rst
+++ b/docs/en/seccons_bcps.rst
@@ -32,8 +32,8 @@ At the same time, the specifications of OIDC Federation 1.0 don't define a limit
 
 
 
-Resolve Entity Statement
-++++++++++++++++++++++++
+Resolve endpoint
+++++++++++++++++
 
 This endpoint MUST release the Metadata, the Trust Marks and the previously processed Trust Chain, and MUST
 NOT trigger a procedure of Federation Entity Discovery for each request arrival.

--- a/docs/en/trust_marks.rst
+++ b/docs/en/trust_marks.rst
@@ -150,8 +150,7 @@ There are two ways of validating a Trust Mark:
 
  2. **Dynamic** Validation. The Federation members can query the endpoint :ref:`trust mark status<federation_endpoint>` supplied by its issuer (claim **iss**), for a real-time checking of the TMs that it has issued.
 
-All the Entities that release Trust Marks, MUST expose a Trust Mark status endpoint for allowing the 
-**dynamic** validation.
+All the Entities that release Trust Marks, MUST expose a Trust Mark status endpoint for allowing the **dynamic** validation.
 
 .. seealso:: 
 

--- a/docs/it/differenze_oidc_fed.rst
+++ b/docs/it/differenze_oidc_fed.rst
@@ -12,7 +12,7 @@ In questa sezione sono elencate le differenze che intercorrono tra lo standard u
 Client Registration
 +++++++++++++++++++
 
-SPID supporta esclusivamente **automatic_client_registration**. La modalità **implicit** è da intendersi come non supportata. 
+SPID e CIE supportano esclusivamente **automatic_client_registration**. La modalità **implicit** è da intendersi come non supportata. 
 
 
 Trust Mark

--- a/docs/it/differenze_oidc_fed.rst
+++ b/docs/it/differenze_oidc_fed.rst
@@ -6,7 +6,7 @@
 Differenze con OIDC Federation
 ------------------------------
 
-In questa sezione sono elencate le differenze che intercorrono tra lo standard ufficiale e l'implementazione SPID / CIE.
+In questa sezione sono elencate le differenze che intercorrono tra lo standard ufficiale e l'implementazione SPID e CIE.
 
 
 Client Registration
@@ -15,16 +15,10 @@ Client Registration
 SPID supporta esclusivamente **automatic_client_registration**. La modalità **implicit** è da intendersi come non supportata. 
 
 
-Listing endpoint
-++++++++++++++++
-
-In SPID e CIE id viene adottato il parametro aggiuntivo **entity_type** a quelli esistenti nello Standard `OIDC-FED`_ per questo endpoint, con lo scopo di ottenere un filtro sulla tipologia delle entità discendenti. Questa esigenza consente nello specifico di filtrare entità di tipo **federation_entity**, **openid_relying_party**, **openid_provider** e **oauth_resource**.
-
-
 Trust Mark
 ++++++++++
 
-In SPID e CIE id l'uso dei Trust Mark non è obbligatorio. In SPID piuttosto l'esposizione dei Trust Mark è obbligatoria. Per approfondimenti sulla ragione dell'obbligo dei Trust Mark si rimanda alla sezione :ref:`Considerazioni di Sicurezza<Considerazioni_di_Sicurezza>`.
+L'esposizione dei Trust Mark in SPID e CIE è obbligatoria. Per approfondimenti sulla ragione dell'obbligo dei Trust Mark si rimanda alla sezione :ref:`Considerazioni di Sicurezza<Considerazioni_di_Sicurezza>`.
 
 
 Claim non supportati negli Entity Statement

--- a/docs/it/differenze_oidc_fed.rst
+++ b/docs/it/differenze_oidc_fed.rst
@@ -12,7 +12,7 @@ In questa sezione sono elencate le differenze che intercorrono tra lo standard u
 Client Registration
 +++++++++++++++++++
 
-SPID e CIE supportano esclusivamente **automatic_client_registration**. La modalità **explicit client registration** è da intendersi come non supportata. 
+SPID e CIE supportano esclusivamente **automatic_client_registration**. La modalità **explicit client registration** non è supportata. 
 
 
 Trust Mark

--- a/docs/it/differenze_oidc_fed.rst
+++ b/docs/it/differenze_oidc_fed.rst
@@ -12,7 +12,7 @@ In questa sezione sono elencate le differenze che intercorrono tra lo standard u
 Client Registration
 +++++++++++++++++++
 
-SPID e CIE supportano esclusivamente **automatic_client_registration**. La modalità **implicit** è da intendersi come non supportata. 
+SPID e CIE supportano esclusivamente **automatic_client_registration**. La modalità **explicit client registration** è da intendersi come non supportata. 
 
 
 Trust Mark

--- a/docs/it/federation_endpoint.rst
+++ b/docs/it/federation_endpoint.rst
@@ -21,8 +21,3 @@ Le entità di tipo **TA** o **SA** DEVONO offrire i seguenti endpoint, in aggiun
  - **entity listing endpoint**: fornisce la lista delle entità discendenti registrate presso il TA o un SA (per maggiori dettagli vedi `OIDC-FED`_ Section 7.3)
 
 Un'entità di tipo **AA**, oltre agli endpoint di Federazione comuni a tutte le entità, DEVE riportare anche il **trust mark status endpoint** per consentire la validazione dinamica dei TM rilasciati dall'AA.
-
-
-.. warning::
-  In accordo a quanto definito in OIDC-FED, all'**entity listing endpoint** si aggiunge il parametro opzionale **entity_type** come filtro sul tipo di entità dei discendenti.
-

--- a/docs/it/seccons_bcps.rst
+++ b/docs/it/seccons_bcps.rst
@@ -28,8 +28,8 @@ La soglia **max_path_lenght** si applica per la navigazione verticale e superata
 Allo stesso tempo la specifica OIDC Federation 1.0 non definisce un limite per il numero di **authority_hints**, questo perché nessun Trust Anchor può limitare il numero di Federazioni alle quali un partecipante può aderire. Per questa ragione è utile che gli implementatori adottino un limite massimo del numero di elementi consentiti all'interno dell'Array authority_hint. Questo per evitare che un numero esagerato di URL contenuti nella lista di **authority_hints**, dovuto ad una cattiva configurazione di una Foglia, produca un consumo di risorse eccessivo.
 
 
-Resolve Entity Statement
-++++++++++++++++++++++++
+Resolve endpoint
+++++++++++++++++
 
 Questo endpoint DEVE rilasciare i Metadata, i Trust Mark e la Trust Chain già precedentemente elaborata e NON DEVE innescare una procedura di Federation Entity Discovery ad ogni richiesta pervenuta.
 

--- a/docs/it/seccons_bcps.rst
+++ b/docs/it/seccons_bcps.rst
@@ -53,8 +53,3 @@ L'interoperabilità tra i partecipanti funziona mediante i Metadata ottenuti dal
 La buona pratica per evitare le interruzioni di servizio relative alle operazioni di OIDC Core è quella di aggiungere le nuove chiavi pubbliche all'interno degli oggetti *jwks* senza rimuovere i valori preesistenti. Oppure, ad esempio, i nuovi *redirect_uri*.
 
 In questa maniera dopo il limite massimo di durata delle Trust Chain, definito con il claim **exp** e pubblicato nella Entity Configuration della TA, si ha la certezza che tutti i partecipanti abbiano rinnovato le loro Trust Chain, e sarà possibile agli amministratori della Foglia rimuovere le vecchie definizioni in cima alla lista.
-
-Politica dei Metadata
-+++++++++++++++++++++
-
-L'Autorità di Federazione o il suo Intermediario PUÒ pubblicare una politica dei Metadata (vedi `OIDC-FED`_ Section 5.1) per forzare la modifica dei Metadata OIDC della Foglia, nelle parti in cui questo fosse necessario.


### PR DESCRIPTION
- [Listing endpoint] entuty_type is in the specs (https://github.com/italia/spid-cie-oidc-docs/issues/103)
- Resolves editorials consideration at https://github.com/italia/spid-cie-oidc-docs/issues/112 and https://github.com/italia/spid-cie-oidc-docs/issues/113
- Trust mark status HTTP method is POST according to the specs (https://github.com/italia/spid-cie-oidc-docs/issues/94)