### PR TITLE
Claim id_code nel Trust Mark

### DIFF
--- a/docs/common/common_examples.rst
+++ b/docs/common/common_examples.rst
@@ -426,7 +426,10 @@ Where the $JWT payload is:
      "sub": "https://rp.esempio.it/",
      "iat": 1579621160,
      "organization_type": "public",
-     "id_code": ["123456","Uff_protocollo"],
+     "id_code": {
+        "ipa_code": "123456",
+        "aoo_code": "Uff_protocollo"
+     }
      "email": "email_or_pec@rp.it",
      "organization_name#it": "Denominazione del RP",
      "ref": "https://documentazione_di_riferimento.it/"
@@ -461,7 +464,9 @@ Where the $JWT payload is:
      "sub": "https://sa.esempio.it/",
      "iat": 1579621160,
      "organization_type": "private",
-     "id_code": ["1234567890"],
+     "id_code": {
+        "fiscal_number": "1234567890"
+     }
      "email": "email_or_pec@intermediate.it",
      "organization_name#it": "Denominazione del SA",
      "sa_profile": "full",
@@ -496,7 +501,9 @@ Where the $JWT payload is:
      "sub": "https://rp.esempio.it/",
      "iat": 1579621160,
      "organization_type": "public",
-     "id_code": ["987654"],
+     "id_code": {
+        "ipa_code": "987654",
+     }
      "email": "email_or_pec@rp.it",
      "organization_name#it": "Denominazione del RP",
      "ref": "https://documentazione_di_riferimento.it/"

--- a/docs/en/trust_marks.rst
+++ b/docs/en/trust_marks.rst
@@ -226,7 +226,7 @@ The claims defined inside the TMs are compliant with the elements defined in the
 
 .. warning::
 
-  The value in the claim **exp** MUST NOT be greater than the duration of the specific agreements made in the onboarding process, between the Trust Mark issuer and the Organizations receiving the TM.
+  The value in the claim **exp** MUST NOT be greater than the duration of the agreements submitted during the onboarding process, between the Trust Mark issuer and the Organizations receiving the TM.
  
 
 .. seealso::

--- a/docs/en/trust_marks.rst
+++ b/docs/en/trust_marks.rst
@@ -210,7 +210,12 @@ The claims defined inside the TMs are compliant with the elements defined in the
       - String. Specifies if the Entity belongs to the Italian Public Administration or the private sector (**public** or **private**)
       - |spid-icon| |cieid-icon|
     * - **id_code**
-      - String Array. Identification code of the Organization. Depending on the Organization type, it MUST contain an IPA code (for the public Organization type) or the VAT number and/or fiscal number (for the private type).
+      - JSON Object. It contains one or more ogranization identification codes. Available claims are: 
+        - **ipa_code**: REQUIRED for public organization.
+        - **aoo_code**: OPTIONAL.
+        - **uo_code**: OPTIONAL. 
+        - **vat_number**: REQUIRED for private organization only if *fiscal_number* is not available.
+        - **fiscal_number**: REQUIRED for private organization only if *vat_number* is not available.
       - |spid-icon| |cieid-icon|
     * - **email**
       - String. Institutional e-mail or PEC of the Organization.
@@ -219,12 +224,9 @@ The claims defined inside the TMs are compliant with the elements defined in the
       - String. The complete name of the service-supplying Entity.
       - |spid-icon| |cieid-icon|
 
-.. admonition:: |cieid-icon|
+.. warning::
 
-  In case of CIE id, the public Organizations having both the IPA code and a unique AOO code, MUST include the latter one in the claim id_code. In this case the claim **id_code** MUST include the IPA Code followed by the unique AOO code.
-  Furthermore, the value in the claim **exp** MUST NOT be greater than the duration of the specific 
-  conventions/agreements concluded in the onboarding process, between the Trust Mark issuer and the Organizations 
-  that receive the TM.
+  The value in the claim **exp** MUST NOT be greater than the duration of the specific agreements made in the onboarding process, between the Trust Mark issuer and the Organizations receiving the TM.
  
 
 .. seealso::

--- a/docs/it/trust_marks.rst
+++ b/docs/it/trust_marks.rst
@@ -184,7 +184,12 @@ Gli attributi definiti all'interno dei TM aderiscono a quanto definito all'inter
       - String. Specifica se l'ente appartiene alla pubblica amministrazione italiana o al settore privato (**public** o **private**)
       - |spid-icon| |cieid-icon|
     * - **id_code**
-      - String Array. Codice di identificazione dell'organizzazione. A seconda del valore del tipo di organizzazione, DEVE contenere almeno: il codice IPA (per il tipo di organizzazione pubblica) o il numero di partita IVA e/o il codice fiscale (per quello privato).
+      - Oggetto JSON. Contiene uno o più codici di identificazione dell'organizzazione. I claim disponibili sono:
+        - **ipa_code**: OBBLIGATORIO nel caso di organizzazione pubblica.
+        - **aoo_code**: OPZIONALE.
+        - **uo_code**: OPZIONALE.
+        - **vat_number**: OBBLIGATORIO per organizzazione privata se non presente *fiscal_number*.
+        - **fiscal_number**: OBBLIGATORIO per organizzazione privata se non presente *vat_number*.
       - |spid-icon| |cieid-icon|
     * - **email**
       - String. Email istituzionale o PEC dell'organizzazione.
@@ -196,9 +201,9 @@ Gli attributi definiti all'interno dei TM aderiscono a quanto definito all'inter
       - String. RICHIESTO per SA. Specifica il profilo dell’Aggregatore, **full** o **light**.
       - |spid-icon| |cieid-icon|
 
-.. admonition:: |cieid-icon|
+.. warning:: 
 
-  Nel caso di CIE id, le organizzazioni pubbliche che oltre al **codice IPA** dispongono anche di un **codice univoco AOO** DEVONO riportare anche quest'ultimo all'interno del parametro **id_code**. In questo caso **id_code** DEVE contenere il **codice IPA** seguito dal **codice univoco AOO**. Inoltre, il valore contenuto nel parametro **exp** NON DEVE essere superiore alla durata delle specifiche convenzioni/accordi stipulati in fase di onboarding tra l'emettitore dei Trust Mark e le organizzazioni che ricevono il TM.  
+   Il valore contenuto nel parametro **exp** NON DEVE essere superiore alla durata delle specifiche convenzioni/accordi stipulati in fase di onboarding tra l'emettitore dei Trust Mark e le organizzazioni che ricevono il TM.  
 
 .. seealso::
 

--- a/docs/it/trust_marks.rst
+++ b/docs/it/trust_marks.rst
@@ -203,7 +203,7 @@ Gli attributi definiti all'interno dei TM aderiscono a quanto definito all'inter
 
 .. warning:: 
 
-   Il valore contenuto nel parametro **exp** NON DEVE essere superiore alla durata delle specifiche convenzioni/accordi stipulati in fase di onboarding tra l'emettitore dei Trust Mark e le organizzazioni che ricevono il TM.  
+   Il valore contenuto nel parametro **exp** NON DEVE essere superiore alla durata delle convenzioni stipulate in fase di onboarding tra l'Entità che rilascia i Trust Mark e le organizzazioni che lo ricevono.  
 
 .. seealso::
 


### PR DESCRIPTION
## Title
Claim id_code nel Trust Mark

## Content
Il claim _id_code_ diventa un JSON Object con la possibilità di aggiungere diversi identificativi dell'organizzazione:
- ipa_code
- aoo_code
- uo_code
- vat_number
- fiscal_number

Resolves #100 

## Review

- [ ] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [x] Example files 
- [ ] Ask for review
