### PR TITLE
Allineamento con Linee guida OIDC - Disambiguazione Scope e claim in ID token

### DIFF
--- a/docs/en/authorization_endpoint.rst
+++ b/docs/en/authorization_endpoint.rst
@@ -6,18 +6,20 @@ Authorization endpoint
 Request
 +++++++
 
-For starting the authentication process, the RP redirects the user to the *Authorization Endpoint* of the selected OP, and sends an *HTTP* request with the parameter **request**, an object in **JWT** format that contains the *Authorization Request* signed by the RP.
+For starting the authentication process, the RP redirects the user to the *Authorization Endpoint* of the selected OP, and sends an *HTTP* request with the parameter **request**, an object in signed **JWT** format that contains the *Authorization Request* signed by the RP.
 
 For conveying the request, the RP MAY use the methods **POST** and **GET**. With the method **POST** the parameters MUST be sent using the *Form Serialization*. 
 With the method **GET** the parameters MUST be sent using the *Query String Serialization*. For more details see `OpenID.Core#Serializations`_.
 
-Request object MUST be a signed JWT. For more details see signature :ref:`supported_algs`.
-
 .. warning::
   The parameter **scope** MUST be sent both as a parameter in the HTTP call, and inside the request object. The two values MUST be the same.
 
-  The parameters **client_id** and **response_type** SHOULD be sent both as parameters in the HTTP call, and inside the request object. 
-  
+  |cieid-icon|
+  The parameters **client_id** and **response_type** SHOULD be sent both as parameters in the HTTP call, and inside the request object.
+
+  |spid-icon|
+  The parameters **client_id** and **response_type** MUST be sent both as parameters in the HTTP call, and inside the request object. The two values MUST be the same, in case of mismatching the values inside the request object MUST be considered.
+
 .. seealso:: 
 
    - :ref:`Example of Authorization Request <Esempio_EN6>`
@@ -156,39 +158,42 @@ The **JWT** payload contains the following mandatory claims:
 Parameters **scope** and **claims**
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The user attributes MAY be requested by the RP using the **scope** or **claims** parameters in the Authorization Request.
+.. admonition:: |spid-icon|
 
-When the **scope** parameter is used, the following values are supported:
+  The user attributes MAY be requested by the RP using the **claims** parameter in the Authorization Request.
 
-- **profile**: the use of this value permits to obtain the default user profile which corresponds to the eIDAS Minimum Dataset: 
-
-    - *family_name*, 
-    - *given_name*,
-    - *birthdate*, 
-    - *\https://attributes.eid.gov.it/fiscal_number* (National Unique Identifier).
-
-- **email**: : this value permits to get, when they are made available by the user, the following attributes:
-
-    - *email*;
-    - *email_verified*. Only for |cieid-icon|
+  SPID do not allow require the user attributes in the Token ID, they are available in the "userinfo".  
 
 
-The parameter **scope** MAY contain one or more values, with single spaces as separators. For example, using both profile and email in the scope parameter returns the Minimum eIDAS Dataset and the email.
-In case of requests of single user-attributes or specific combinations of them, the RP SHOULD use the parameter **claims**.
-For the definition of the parameter **claims** and its usage modes for requesting the user attributes, please refer to `OpenID.Core#ClaimsParameter`_.
+.. admonition:: |cieid-icon|
+
+  The user attributes MAY be requested by the RP using the **scope** or **claims** parameters in the Authorization Request.
+
+  When the **scope** parameter is used, the following values are supported:
+
+  - **profile**: the use of this value permits to obtain the default user profile which corresponds to the eIDAS Minimum Dataset: 
+
+      - *family_name*, 
+      - *given_name*,
+      - *birthdate*, 
+      - *\https://attributes.eid.gov.it/fiscal_number* (National Unique Identifier).
+
+  - **email**: : this value permits to get, when they are made available by the user, the following attributes:
+
+      - *email*;
+      - *email_verified*.
 
 
-.. admonition:: |cieid-icon| |spid-icon|
+  The parameter **scope** MAY contain one or more values, with single spaces as separators. For example, using both profile and email in the scope parameter returns the Minimum eIDAS Dataset and the email.
+  In case of requests of single user-attributes or specific combinations of them, the RP SHOULD use the parameter **claims**.
 
   The attributes requested by the parameter **scope** are available both in the ID Token and in the *userinfo endpoint* response.
 
-.. admonition:: |spid-icon|
-
-  SPID allows the user attributes in the Token ID only if this is encrypted and if the recipient RP contains, within its metadata, the claims *id_token_encrypted_response_alg* and *id_token_encrypted_response_enc*.
-
-.. warning::
+  .. warning::
 
     If in the **scope** parameter there was only the *openid* value and the **claims** parameter was not present or valued, the response of the userinfo endpoint would not have any user attributes but only the claim **sub**.
+
+For the definition of the parameter **claims** and its usage modes for requesting the user attributes, please refer to `OpenID.Core#ClaimsParameter`_.
 
 
 Response

--- a/docs/en/authorization_endpoint.rst
+++ b/docs/en/authorization_endpoint.rst
@@ -6,7 +6,7 @@ Authorization endpoint
 Request
 +++++++
 
-For starting the authentication process, the RP redirects the user to the *Authorization Endpoint* of the selected OP, and sends an *HTTP* request with the parameter **request**, an object in signed **JWT** format that contains the *Authorization Request* signed by the RP.
+To initiate the authentication request, the RP redirects the user to the *Authorization Endpoint* of the selected OP, and sends a *HTTP* request with the parameter **request**, a signed JWT containing the *Authorization Request*.
 
 For conveying the request, the RP MAY use the methods **POST** and **GET**. With the method **POST** the parameters MUST be sent using the *Form Serialization*. 
 With the method **GET** the parameters MUST be sent using the *Query String Serialization*. For more details see `OpenID.Core#Serializations`_.
@@ -162,7 +162,7 @@ Parameters **scope** and **claims**
 
   The user attributes MAY be requested by the RP using the **claims** parameter in the Authorization Request.
 
-  SPID do not allow require the user attributes in the Token ID, they are available in the "userinfo".  
+  SPID do not allow require the user attributes in Token ID, they are available in "userinfo".  
 
 
 .. admonition:: |cieid-icon|
@@ -171,14 +171,14 @@ Parameters **scope** and **claims**
 
   When the **scope** parameter is used, the following values are supported:
 
-  - **profile**: the use of this value permits to obtain the default user profile which corresponds to the eIDAS Minimum Dataset: 
+  - **profile**: requests the user attributes equivalent to the eIDAS Minimum Dataset: 
 
       - *family_name*, 
       - *given_name*,
       - *birthdate*, 
       - *\https://attributes.eid.gov.it/fiscal_number* (National Unique Identifier).
 
-  - **email**: : this value permits to get, when they are made available by the user, the following attributes:
+  - **email**: requests the following attributes:
 
       - *email*;
       - *email_verified*.

--- a/docs/en/introspection_endpoint.rst
+++ b/docs/en/introspection_endpoint.rst
@@ -62,7 +62,7 @@ together with a Client Assertion that allows authenticating the RP that makes th
      - |spid-icon| |cieid-icon| 
    * - **token**
      - The token about which the RP wants to obtain information.
-     - 
+     - |spid-icon| |cieid-icon|  
 
 
 Response
@@ -88,7 +88,7 @@ The Introspection Endpoint responds with a JSON Object defined as follows.
    * - **active**
      - Boolean value that indicates the token validity. If the token is expired, it has been revoked or it
        has never been issued for the calling client_id, the Introspection Endpoint must return false.
-     -  |spid-icon|
+     -  |spid-icon| |cieid-icon|
    * - **scope**
      - List of scopes required in the Authorization Request.
      -  |spid-icon|

--- a/docs/en/introspection_endpoint.rst
+++ b/docs/en/introspection_endpoint.rst
@@ -46,20 +46,20 @@ together with a Client Assertion that allows authenticating the RP that makes th
 
    * - **Claim**
      - **Description**
-     - **Required**
+     - **Supported by**
    * - **client_assertion**
      - JWT signed with the Relying Party's private key, containing the same parameters as documented 
        for the requests to the Token Endpoint. The OP must test the validity of all the fields that
        are present in the JWT, plus the validity of its signature, 
        with respect to the parameter **client_id**.
-     - 
+     - |spid-icon| |cieid-icon|
    * - **client_assertion_type**
      - String. Allowed values: **urn:ietf:params:oauth:clientassertion-type:jwt-bearer**
-     - 
+     - |spid-icon| |cieid-icon| 
    * - **client_id**
      - URI that unquely identifies the RP. The OP must check that the client_id is known inside the 
        Federation.
-     - 
+     - |spid-icon| |cieid-icon| 
    * - **token**
      - The token about which the RP wants to obtain information.
      - 
@@ -84,11 +84,29 @@ The Introspection Endpoint responds with a JSON Object defined as follows.
 
    * - **Claim**
      - **Description**
-     - **Required**
+     - **Supported by**
    * - **active**
      - Boolean value that indicates the token validity. If the token is expired, it has been revoked or it
        has never been issued for the calling client_id, the Introspection Endpoint must return false.
-     - 
+     -  |spid-icon|
+   * - **scope**
+     - List of scopes required in the Authorization Request.
+     -  |spid-icon|
+   * - **exp**
+     - Token expiration.
+     -  |spid-icon|
+   * - **sub**
+     - Subject identifier. The same released in the ID Token. The RP MUST verify that the value is the same contained in the ID Token.
+     -  |spid-icon|
+   * - **client_id**
+     - URI of the RP registered in the federation. The RP MUST verify that the value is the same of the own client_id.
+     -  |spid-icon|
+   * - **iss**
+     - OP identified registered in the federation in Uniform Resource Locator (URL) format. The RP MUST verify that the value is the same of the OP queried.
+     -  |spid-icon|
+   * - **aud**
+     - RP client ID.	The RP MUST verify that the value is the same of the own client ID.
+     -  |spid-icon|
 
 Error Codes
 +++++++++++

--- a/docs/it/authorization_endpoint.rst
+++ b/docs/it/authorization_endpoint.rst
@@ -6,17 +6,19 @@ Authorization endpoint (Authentication)
 Request
 +++++++
 
-Per avviare il processo di autenticazione, il RP reindirizza l'utente all'*Authorization Endpoint* dell'OP selezionato, inviando una richiesta *HTTP* contenente il parametro **request** un oggetto in formato **JWT** che contiene l'*Authorization Request* firmata dal RP.
+Per avviare il processo di autenticazione, il RP reindirizza l'utente all'*Authorization Endpoint* dell'OP selezionato, inviando una richiesta *HTTP* contenente il parametro **request** un oggetto in formato **JWT** firmato che contiene l'*Authorization Request* firmata dal RP.
 
 Per veicolare la richiesta, il RP PUÒ utilizzare i metodi **POST** e **GET**. Mediante il metodo **POST** i parametri DEVONO essere trasmessi utilizzando la *Form Serialization*. 
 Mediante il metodo **GET** i parametri DEVONO essere trasmessi utilizzando la *Query String Serialization*. Per maggiori dettagli vedi `OpenID.Core#Serializations`_.
 
-L’oggetto request DEVE essere un token JWT firmato, vedi signature :ref:`supported_algs`.
-
 .. warning::
   Il parametro **scope** DEVE essere trasmesso sia come parametro nella chiamata HTTP sia all'interno dell'oggetto request e i loro valori DEVONO corrispondere.
 
+  |cieid-icon|
   I parametri **client_id** e **response_type** DOVREBBERO essere trasmessi sia come parametri sulla chiamata HTTP sia all'interno dell'oggetto request.
+
+  |spid-icon|
+  I parametri **client_id** e **response_type** DEVONO essere trasmessi sia come parametri sulla chiamata HTTP sia all'interno dell'oggetto request e i loro valori DEVONO corrispondere, in ogni caso i parametri all’interno dell’oggetto request prevalgono su quelli indicati sulla chiamata HTTP.
 
 .. seealso:: 
 
@@ -148,38 +150,43 @@ Il payload del **JWT** contiene i seguenti parametri obbligatori.
 Parametri **scope** e **claims**
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Gli attributi dell'utente POSSONO essere richiesti dal RP nell'Authorization Request usando i parametri **scope** o **claims**.
-
-
-Nel caso di utilizzo del parametro **scope** i seguenti valori sono supportati:
-
-- **profile**: usando questo valore è possibile ottenere il profilo utente di default che corrisponde al Minimum Dataset eIDAS: 
-
-    - *family_name*, 
-    - *given_name*,
-    - *birthdate*, 
-    - *\https://attributes.eid.gov.it/fiscal_number* (National Unique Identifier).
-
-- **email**: questo valore permette di ottenere, se resi disponibili dall'utente, i seguenti attributi:
-
-    - *email*,
-    - *email_verified*. Solo per |cieid-icon|
-
-Il parametro **scope** PUÒ contenere uno o più valori separati da uno spazio. Ad esempio l'utilizzo congiunto di *profile* e *email* permette di ottenere l'unione degli insiemi degli attributi (Minimum Dataset eIDAS e l'email).
-Nel caso di richiesta di singoli attributi dell'utente o specifiche combinazioni di essi, Il RP DOVREBBE usare il parametro **claims**.
-Per la definizione del parametro **claims** e la modalità di utilizzo per la richiesta degli attributi dell'utente si può fare riferimento a `OpenID.Core#ClaimsParameter`_.
-
-.. note:: |cieid-icon| |spid-icon|
-
-    Gli attributi richiesti tramite il parametro **scope** sono disponibili sia nell'ID Token e sia nella risposta allo *userinfo endpoint*.
-
 .. admonition:: |spid-icon|
 
-  SPID consente gli attributi utente nell' ID Token esclusivamente se questo è criptato e se il RP destinatoraio contiene, all'interno dei suoi metadata,  i claims *id_token_encrypted_response_alg* e *id_token_encrypted_response_enc*.
+  Gli attributi dell'utente POSSONO essere richiesti dal RP nell'Authorization Request usando il parametro **claims**.
 
-.. warning::
+  Non è possibile richiedere attributi SPID nell’id_token. Gli attributi elencati sotto "userinfo" sono disponibili al momento della chiamata allo UserInfo Endpoint.
 
-  Se nel parametro **scope** vi fosse esclusivamente il valore **openid** e il parametro **claims** non fosse presente o valorizzato, la response dello userinfo endpoint non presenterebbe alcun attributo utente ma soltanto il claim *sub*.
+
+
+.. admonition:: |cieid-icon|
+
+  Gli attributi dell'utente POSSONO essere richiesti dal RP nell'Authorization Request usando i parametri **scope** o **claims**.
+
+
+  Nel caso di utilizzo del parametro **scope** i seguenti valori sono supportati:
+
+  - **profile**: usando questo valore è possibile ottenere il profilo utente di default che corrisponde al Minimum Dataset eIDAS: 
+
+      - *family_name*, 
+      - *given_name*,
+      - *birthdate*, 
+      - *\https://attributes.eid.gov.it/fiscal_number* (National Unique Identifier).
+
+  - **email**: questo valore permette di ottenere, se resi disponibili dall'utente, i seguenti attributi:
+
+      - *email*,
+      - *email_verified*.
+
+  Il parametro **scope** PUÒ contenere uno o più valori separati da uno spazio. Ad esempio l'utilizzo congiunto di *profile* e *email* permette di ottenere l'unione degli insiemi degli attributi (Minimum Dataset eIDAS e l'email).
+  Nel caso di richiesta di singoli attributi dell'utente o specifiche combinazioni di essi, Il RP DOVREBBE usare il parametro **claims**.
+
+  Gli attributi richiesti tramite il parametro **scope** sono disponibili sia nell'ID Token e sia nella risposta allo *userinfo endpoint*.
+
+  .. warning::
+
+    Se nel parametro **scope** vi fosse esclusivamente il valore **openid** e il parametro **claims** non fosse presente o valorizzato, la response dello userinfo endpoint non presenterebbe alcun attributo utente ma soltanto il claim *sub*.
+
+Per la definizione del parametro **claims** e la modalità di utilizzo per la richiesta degli attributi dell'utente si può fare riferimento a `OpenID.Core#ClaimsParameter`_.
 
 
 Response

--- a/docs/it/introspection_endpoint.rst
+++ b/docs/it/introspection_endpoint.rst
@@ -82,7 +82,7 @@ L'Introspection Endpoint risponde con un oggetto JSON definito come segue.
      - **Supportato da**
    * - **active**
      - Valore booleano che indica la validità del token. Se il token è scaduto, è revocato o non è mai stato emesso per il client_id chiamante, l'Introspection Endpoint deve restituire false.
-     -  |spid-icon|
+     -  |spid-icon| |cieid-icon|
    * - **scope**
      - Lista degli scope richiesti al momento dell’Authorization Request.
      -  |spid-icon|

--- a/docs/it/introspection_endpoint.rst
+++ b/docs/it/introspection_endpoint.rst
@@ -44,20 +44,20 @@ La richiesta all'Introspection Endpoint consiste nell'invio del token su cui si 
 
    * - **Claim**
      - **Descrizione**
-     - **Obbligatorio**
+     - **Supportato da**
    * - **client_assertion**
      - JWT firmato con la chiave privata del Relying Party contenente gli stessi parametri documentati per le richieste al 
        Token Endpoint. L'OP deve verificare la validità di tutti i campi presenti nel JWT, nonché la validità della sua firma in relazione al parametro **client_id**.
-     - 
+     - |spid-icon| |cieid-icon|
    * - **client_assertion_type**
      - String. Valori ammessi: **urn:ietf:params:oauth:clientassertion-type:jwt-bearer**
-     - 
+     - |spid-icon| |cieid-icon|
    * - **client_id**
      - URI che identifica univocamente il RP. L'OP deve verificare che il client_id sia noto all'interno della Federazione.
-     - 
+     - |spid-icon| |cieid-icon|
    * - **token**
      - Il token su cui il RP vuole ottenere informazioni.
-     - 
+     - |spid-icon| |cieid-icon|
 
 
 Response
@@ -79,10 +79,28 @@ L'Introspection Endpoint risponde con un oggetto JSON definito come segue.
 
    * - **Claim**
      - **Descrizione**
-     - **Obbligatorio**
+     - **Supportato da**
    * - **active**
      - Valore booleano che indica la validità del token. Se il token è scaduto, è revocato o non è mai stato emesso per il client_id chiamante, l'Introspection Endpoint deve restituire false.
-     - 
+     -  |spid-icon|
+   * - **scope**
+     - Lista degli scope richiesti al momento dell’Authorization Request.
+     -  |spid-icon|
+   * - **exp**
+     - Scadenza del token.
+     -  |spid-icon|
+   * - **sub**
+     - Identificatore del soggetto, coincidente con quello già rilasciato nell’ID Token. Il RP deve verificare che il valore coincida con quello contenuto nell’ID Token.
+     -  |spid-icon|
+   * - **client_id**
+     - URI che identifica univocamente il RP come da Registro SPID. Il RP deve verificare che il valore coincida con il proprio client_id.
+     -  |spid-icon|
+   * - **iss**
+     - Identificatore dell’OP che lo contraddistingue univocamente nella federazione nel formato Uniform Resource Locator (URL). Il client è tenuto a verificare che questo valore corrisponda all’OP chiamato.
+     -  |spid-icon|
+   * - **aud**
+     - Contiene il client ID.	Il client è tenuto a verificare che questo valore corrisponda al proprio client ID.
+     -  |spid-icon|
 
 Codici di errore
 ++++++++++++++++


### PR DESCRIPTION
## Title
Allineamento con Linee guida OIDC - Disambiguazione Scope e claim in ID token
## Content
Disambiguazione per evidenziare che: 
gli scope sono usati solo da CIE
in spid i claim sono solo nello userinfo
## Review

- [ ] Ensure your files are written following RST specs (*not MD!*)
- [ ] Italian version
- [ ] English version
- [ ] Example files 
- [ ] Ask for review
