### PR TITLE
id_code usage in the web path for SA FULL

### DIFF
--- a/docs/en/soggetti_aggregatori.rst
+++ b/docs/en/soggetti_aggregatori.rst
@@ -14,7 +14,7 @@ The **Full** SAs arrange building an authentication and federation interface, on
     - **.well-known/openid-federation**, containing the Leaf's Entity Configuration;
     - Authorization callback endpoint for obtaining the auth code by the OP (**redirect_uri**).
 
-The **Full** type SAs MUST add the **id_code** (as defined in the Section :ref:`Trust Mark Composition <ComposizioneTM>`) inside the web path, which in turn is inside the client_id that identifies the subordinate Entity ``<SA_domain>/<id_code>/``.
+The **Full** type SAs MUST add at least one of the available identification code in the **id_code** (as defined in the Section :ref:`Trust Mark Composition <ComposizioneTM>`) inside the web path, which in turn is inside the client_id that identifies the subordinate Entity ``<SA_domain>/<id_code>/``. If more than one identification code is available, the SA MAY include them in the web path as in the following example: ``<SA_domain>/ipa_code/aoo_code/``.
 
 The following table contains some non-normative examples for outlining the differences between the SAs of
 types Light and Full:

--- a/docs/it/soggetti_aggregatori.rst
+++ b/docs/it/soggetti_aggregatori.rst
@@ -9,12 +9,12 @@ Un SA può registrare RP preesistenti e già conformi allo standard OIDC-FED, af
 
 I SA **Light** registrano RP preesistenti e conformi a OIDC-FED e pubblicano gli ES a questi riferiti.
 
-I SA **Full** provvedono a costruire una interfaccia di autenticazione e federazione per conto dei propri aggregati, mediante risorse web solitamente esposte all’interno del proprio dominio. Questa tipologia di Aggregatore espone le seguenti risorse per ogni suo aggregato:
+I SA **Full** provvedono a costruire una interfaccia di autenticazione e federazione per conto dei propri aggregati, mediante risorse web solitamente esposte all'interno del proprio dominio. Questa tipologia di Aggregatore espone le seguenti risorse per ogni suo aggregato:
 
     - **.well-known/openid-federation**, contenente la Entity Configuration del proprio discendente (aggregato);
-    - Authorization callback endpoint per l’acquisizione dell’auth code da parte del OP (**redirect_uri**).
+    - Authorization callback endpoint per l'acquisizione dell'auth code da parte del OP (**redirect_uri**).
 
-Il SA di tipo **Full** DEVE aggiungere l'**id_code** (così come definito nella Sezione :ref:`Composizione dei Trust Mark <ComposizioneTM>`), all’interno del web path che compone il client_id, questo identifica univocamente all'interno della federazione l’aggregato ``<SA_domain>/<id_code>/``.
+Il SA di tipo **Full** DEVE aggiungere almeno uno dei codici identificativi presenti nell'**id_code** (così come definito nella Sezione :ref:`Composizione dei Trust Mark <ComposizioneTM>`), all'interno del web path che compone il client_id, questo identifica univocamente all'interno della federazione l'aggregato ``<SA_domain>/<id_code>/``. Se sono disponibili più di un codice identificativo, il SA PUÒ riportarli nel web path come nel seguente esempio: ``<SA_domain>/ipa_code/aoo_code/``.
 
 Nella seguente tabella sono presenti alcuni esempi non normativi per evidenziare le differenze tra gli aggregati Light e Full:
 


### PR DESCRIPTION
## Title
Utilizzo dell'id_code per la costruzione del web path per SA di tipo FULL
## Content
Specificato come costruire il web path nel caso di SA FULL, a partire dall'id_code (oggetto JSON) presente nel trust mark

resolves #146 

## Review

- [ ] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [ ] Example files 
- [ ] Ask for review
