### PR TITLE
Update Error HTTP Status Code

### DIFF
--- a/docs/en/token_endpoint.rst
+++ b/docs/en/token_endpoint.rst
@@ -423,10 +423,10 @@ Error codes
 
   * - *server_error*
     - The OP encountered an internal problem.
-    - *400 Bad Request*
+    - *500 internal server error*
     - |spid-icon| |cieid-icon|
 
   * - *temporarily_unavailable*
     - The OP encountered a temporary internal problem.
-    - *400 Bad Request*
+    - *503 Service Unavailable*
     - |spid-icon| |cieid-icon|

--- a/docs/it/token_endpoint.rst
+++ b/docs/it/token_endpoint.rst
@@ -416,10 +416,10 @@ Codici di errore
 
   * - *server_error*
     - L'OP ha riscontrato un problema interno (:rfc:`6749#section-5.2`).
-    - *400 Bad Request*
+    - *500 Internal Server Error*
     - |spid-icon| |cieid-icon|
 
   * - *temporarily_unavailable*
     - L'OP ha riscontrato un problema interno temporaneo (:rfc:`6749#section-5.2`).
-    - *400 Bad Request*
+    - *503 Service Unavailable*
     - |spid-icon| |cieid-icon|


### PR DESCRIPTION
## Title
Update HTTP Status Code

## Content
[RFC6749](https://datatracker.ietf.org/doc/html/rfc6749.html#section-5.2) does not define the cases server_error and temporarily_unavailable. If we want to define them, I think is more correct to use  standard HTTP Status Code.

- 500 server_error
- 503 temporarily_unavailable

## Review

- [X] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [ ] Example files 
- [X] Ask for review
