### PR TITLE
Update HTTP Status Code - it

### DIFF
--- a/docs/it/token_endpoint.rst
+++ b/docs/it/token_endpoint.rst
@@ -416,10 +416,10 @@ Codici di errore
 
   * - *server_error*
     - L'OP ha riscontrato un problema interno (:rfc:`6749#section-5.2`).
-    - *400 Bad Request*
+    - *500 Internal Server Error*
     - |spid-icon| |cieid-icon|
 
   * - *temporarily_unavailable*
     - L'OP ha riscontrato un problema interno temporaneo (:rfc:`6749#section-5.2`).
-    - *400 Bad Request*
+    - *503 Service Unavailable*
     - |spid-icon| |cieid-icon|


### PR DESCRIPTION
RFC6749 does not define the cases server_error and temporarily_unavailable. If we want to define them, I think is more correct to use standard HTTP Status Code.