### PR TITLE
Fix typos

### DIFF
--- a/docs/common/common_examples.rst
+++ b/docs/common/common_examples.rst
@@ -819,31 +819,92 @@ The following example shows a Metadata policy in the Entity Statement provided b
                     ]
             },
             "grant_types": {
-                "subset_of": ["authorization_code", "refresh_token"]
+                "subset_of": [
+                    "authorization_code",
+                    "refresh_token"
+                ],
+                "superset_of": [
+                    "authorization_code"
+                ]
             },
             "id_token_signed_response_alg": {
-                "one_of": ["RS256", "RS512", "ES256", "ES512", "PS256", "PS512"]
+                "one_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "essential": true
             },
             "id_token_encrypted_response_alg": {
-                "one_of": ["RSA-OAEP", "RSA-OAEP-256", "ECDH-ES", "ECDH-ES+A128KW", "ECDH-ES+A256KW"]
+                "one_of": [
+                    "RSA-OAEP",
+                    "RSA-OAEP-256",
+                    "ECDH-ES",
+                    "ECDH-ES+A128KW",
+                    "ECDH-ES+A256KW"
+                ],
+                "essential": false
             },
             "id_token_encrypted_response_enc": {
-                "one_of": ["A128CBC-HS256", "A256CBC-HS512"]
+                "one_of": [
+                    "A128CBC-HS256",
+                    "A256CBC-HS512"
+                ],
+                "essential": false
             },
             "userinfo_signed_response_alg": {
-                "one_of": ["RS256", "RS512", "ES256", "ES512", "PS256", "PS512"]
+                "one_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "essential": true
             },
             "userinfo_encrypted_response_alg": {
-                "one_of": ["RSA-OAEP", "RSA-OAEP-256", "ECDH-ES", "ECDH-ES+A128KW", "ECDH-ES+A256KW"]
+                "one_of": [
+                    "RSA-OAEP",
+                    "RSA-OAEP-256",
+                    "ECDH-ES",
+                    "ECDH-ES+A128KW",
+                    "ECDH-ES+A256KW"
+                ],
+                "essential": true
             },
             "userinfo_encrypted_response_enc": {
-                "one_of": ["A128CBC-HS256", "A256CBC-HS512"]
+                "one_of": [
+                    "A128CBC-HS256",
+                    "A256CBC-HS512"
+                ],
+                "essential": true
             },
             "token_endpoint_auth_method": {
-                "one_of": ["private_key_jwt"]
+                "one_of": [
+                    "private_key_jwt"
+                ],
+                "essential": true
             },
             "client_registration_types": {
-                "one_of": ["automatic"]
+                "subset_of": [
+                    "automatic"
+                ],
+                "essential": true
+            },
+            "redirect_uris": {
+                "essential": true
+            },
+            "client_id": {
+                "essential": true
+            },
+            "response_types": {
+                "value": [
+                    "code"
+                ]
             }
         }
     }
@@ -855,31 +916,92 @@ The following example shows a Metadata policy in the Entity Statement provided b
     "metadata_policy": {
         "openid_relying_party": {
             "grant_types": {
-                "subset_of": ["authorization_code", "refresh_token"]
-            }
+                "subset_of": [
+                    "authorization_code",
+                    "refresh_token"
+                ],
+                "superset_of": [
+                    "authorization_code"
+                ]
+            },
             "id_token_signed_response_alg": {
-                "one_of": ["RS256", "RS512", "ES256", "ES512", "PS256", "PS512"]
+                "one_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "essential": true
             },
             "id_token_encrypted_response_alg": {
-                "one_of": ["RSA-OAEP", "RSA-OAEP-256", "ECDH-ES", "ECDH-ES+A128KW", "ECDH-ES+A256KW"]
+                "one_of": [
+                    "RSA-OAEP",
+                    "RSA-OAEP-256",
+                    "ECDH-ES",
+                    "ECDH-ES+A128KW",
+                    "ECDH-ES+A256KW"
+                ],
+                "essential": false
             },
             "id_token_encrypted_response_enc": {
-                "one_of": ["A128CBC-HS256", "A256CBC-HS512"]
+                "one_of": [
+                    "A128CBC-HS256",
+                    "A256CBC-HS512"
+                ],
+                "essential": false
             },
             "userinfo_signed_response_alg": {
-                "one_of": ["RS256", "RS512", "ES256", "ES512", "PS256", "PS512"]
+                "one_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "essential": true
             },
             "userinfo_encrypted_response_alg": {
-                "one_of": ["RSA-OAEP", "RSA-OAEP-256", "ECDH-ES", "ECDH-ES+A128KW", "ECDH-ES+A256KW"]
+                "one_of": [
+                    "RSA-OAEP",
+                    "RSA-OAEP-256",
+                    "ECDH-ES",
+                    "ECDH-ES+A128KW",
+                    "ECDH-ES+A256KW"
+                ],
+                "essential": true
             },
             "userinfo_encrypted_response_enc": {
-                "one_of": ["A128CBC-HS256", "A256CBC-HS512"]
+                "one_of": [
+                    "A128CBC-HS256",
+                    "A256CBC-HS512"
+                ],
+                "essential": true
             },
             "token_endpoint_auth_method": {
-                "one_of": ["private_key_jwt"]
+                "one_of": [
+                    "private_key_jwt"
+                ],
+                "essential": true
             },
             "client_registration_types": {
-                "one_of": ["automatic"]
+                "subset_of": [
+                    "automatic"
+                ],
+                "essential": true
+            },
+            "redirect_uris": {
+                "essential": true
+            },
+            "client_id": {
+                "essential": true
+            },
+            "response_types": {
+                "value": [
+                    "code"
+                ]
             }
         }
     }
@@ -939,70 +1061,272 @@ The following example shows a Metadata policy in the Entity Statement provided b
                     ]
             },
             "revocation_endpoint_auth_methods_supported": {
-                "one_of": ["private_key_jwt"]
+                "subset_of": [
+                    "private_key_jwt"
+                ],
+                "essential": true
             },
             "code_challenge_methods_supported": {
-                "subset_of": ["authorization_code", "refresh_token"]
+                "subset_of": [
+                    "S256"
+                ],
+                "essential": true
             },
             "scopes_supported": {
-                "subset_of": ["openid", "offline_access", "profile", "email"]
+                "subset_of": [
+                    "openid",
+                    "offline_access",
+                    "profile",
+                    "email"
+                ],
+                "superset_of": [
+                    "openid",
+                    "offline_access"
+                ]
             },
             "response_types_supported": {
-                "one_of": ["code"]
+                "subset_of": [
+                    "code"
+                ],
+                "essential": true
             },
             "response_modes_supported": {
-                "subset_of": ["form_post", "query"]
+                "subset_of": [
+                    "form_post",
+                    "query"
+                ],
+                "superset_of": [
+                    "form_post",
+                    "query"
+                ],
+                "essential": true
             },
             "grant_types_supported": {
-                "subset_of": ["authorization_code", "refresh_token"]
+                "subset_of": [
+                    "authorization_code",
+                    "refresh_token"
+                ],
+                "superset_of": [
+                    "authorization_code",
+                    "refresh_token"
+                ],
+                "essential": true
             },
             "acr_values_supported": {
-                "subset_of": ["https://www.spid.gov.it/SpidL1", "https://www.spid.gov.it/SpidL2", "https://www.spid.gov.it/SpidL3"]
+                "subset_of": [
+                    "https://www.spid.gov.it/SpidL1",
+                    "https://www.spid.gov.it/SpidL2",
+                    "https://www.spid.gov.it/SpidL3"
+                ],
+                "superset_of": [
+                    "https://www.spid.gov.it/SpidL1",
+                    "https://www.spid.gov.it/SpidL2",
+                    "https://www.spid.gov.it/SpidL3"
+                ],
+                "essential": true
             },
             "subject_types_supported": {
-                "one_of": ["pairwise"]
+                "subset_of": [
+                    "pairwise"
+                ],
+                "essential": true
             },
             "id_token_signing_alg_values_supported": {
-                "one_of": ["RS256", "RS512", "ES256", "ES512", "PS256", "PS512"]
+                "subset_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "superset_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "essential": true
             },
             "id_token_encryption_alg_values_supported": {
-                "one_of": ["RSA-OAEP", "RSA-OAEP-256", "ECDH-ES", "ECDH-ES+A128KW", "ECDH-ES+A256KW"]
+                "subset_of": [
+                    "RSA-OAEP",
+                    "RSA-OAEP-256",
+                    "ECDH-ES",
+                    "ECDH-ES+A128KW",
+                    "ECDH-ES+A256KW"
+                ],
+                "superset_of": [
+                    "RSA-OAEP",
+                    "RSA-OAEP-256",
+                    "ECDH-ES",
+                    "ECDH-ES+A128KW",
+                    "ECDH-ES+A256KW"
+                ],
+                "essential": true
             },
             "id_token_encryption_enc_values_supported": {
-                "one_of": ["A128CBC-HS256", "A256CBC-HS512"]
+                "subset_of": [
+                    "A128CBC-HS256",
+                    "A256CBC-HS512"
+                ],
+                "superset_of": [
+                    "A128CBC-HS256",
+                    "A256CBC-HS512"
+                ],
+                "essential": true
             },
             "userinfo_signing_alg_values_supported": {
-                "one_of": ["RS256", "RS512", "ES256", "ES512", "PS256", "PS512"]
+                "subset_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "superset_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "essential": true
             },
             "userinfo_encryption_alg_values_supported": {
-                "one_of": ["RSA-OAEP", "RSA-OAEP-256", "ECDH-ES", "ECDH-ES+A128KW", "ECDH-ES+A256KW"]
+                "subset_of": [
+                    "RSA-OAEP",
+                    "RSA-OAEP-256",
+                    "ECDH-ES",
+                    "ECDH-ES+A128KW",
+                    "ECDH-ES+A256KW"
+                ],
+                "superset_of": [
+                    "RSA-OAEP",
+                    "RSA-OAEP-256",
+                    "ECDH-ES",
+                    "ECDH-ES+A128KW",
+                    "ECDH-ES+A256KW"
+                ],
+                "essential": true
             },
             "userinfo_encryption_enc_values_supported": {
-                "one_of": ["A128CBC-HS256", "A256CBC-HS512"]
+                "subset_of": [
+                    "A128CBC-HS256",
+                    "A256CBC-HS512"
+                ],
+                "superset_of": [
+                    "A128CBC-HS256",
+                    "A256CBC-HS512"
+                ],
+                "essential": true
             },
             "token_endpoint_auth_methods_supported": {
-                "one_of": ["private_key_jwt"]
+                "subset_of": [
+                    "private_key_jwt"
+                ],
+                "essential": true
             },
             "token_endpoint_auth_signing_alg_values_supported": {
-                "one_of": ["RS256", "RS512", "ES256", "ES512", "PS256", "PS512"]
+                "subset_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "superset_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "essential": true
             },
             "claims_parameter_supported": {
-                "one_of": ["true"]
+                "value": true
             },
             "request_parameter_supported": {
-                "one_of": ["true"]
+                "value": true
             },
             "authorization_response_iss_parameter_supported": {
-                "one_of": ["true"]
+                "value": true
             },
             "client_registration_types_supported": {
-                "one_of": ["automatic"]
+                "subset_of": [
+                    "automatic"
+                ],
+                "essential": true
             },
             "request_authentication_methods_supported": {
-                "one_of": ["request_object"]
+                "value": {
+                    "authorization_endpoint": [
+                        "request_object"
+                    ]
+                }
             },
             "request_authentication_signing_alg_values_supported": {
-                "subset_of": ["RS256", "RS512", "ES256", "ES512", "PS256", "PS512"]
+                "subset_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "superset_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "essential": true
+            },
+            "request_object_signing_alg_values_supported": {
+                "subset_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "superset_of": [
+                    "RS256",
+                    "RS512",
+                    "ES256",
+                    "ES512",
+                    "PS256",
+                    "PS512"
+                ],
+                "essential": true
+            },
+            "issuer": {
+                "essential": true
+            },
+            "authorization_endpoint": {
+                "essential": true
+            },
+            "token_endpoint": {
+                "essential": true
+            },
+            "userinfo_endpoint": {
+                "essential": true
+            },
+            "introspection_endpoint": {
+                "essential": true
+            },
+            "revocation_endpoint": {
+                "essential": true
             }
         }
     }

--- a/docs/common/common_examples.rst
+++ b/docs/common/common_examples.rst
@@ -516,7 +516,7 @@ Where the $JWT payload is:
 EN 2. Entity Statement Request
 ++++++++++++++++++++++++++++++
 
-.. code-block:: http
+.. code-block:: 
 
  GET /fetch?sub=https://rp.example.it/
  HTTP/1.1
@@ -589,7 +589,7 @@ EN 2.1 Entity Statement Response
 EN 3. Entity List Request
 +++++++++++++++++++++++++
 
-.. code-block:: http
+.. code-block:: 
 
  GET /list?entity_type=openid_provider
  HTTP/1.1
@@ -602,7 +602,7 @@ EN 3. Entity List Request
 EN 3.1. Entity List Response
 ++++++++++++++++++++++++++++
 
-.. code-block:: http
+.. code-block:: 
 
  HTTP/1.1 200 OK
  Last-Modified: Wed, 22 Jul 2018 19:15:56 GMT
@@ -615,7 +615,7 @@ EN 3.1. Entity List Response
 EN 4. Resolve Entity Statement Endpoint Request
 +++++++++++++++++++++++++++++++++++++++++++++++
 
-.. code-block:: http
+.. code-block:: 
 
  GET /resolve/?sub=https://openid.provider.it/&anchor=https://registry.agid.gov.it/
  HTTP/1.1
@@ -722,7 +722,7 @@ EN 6. Authorization Request
 
 **Example (HTTP request):**
 
-.. code-block:: http
+.. code-block:: 
 
   GET /auth?client_id=https://rp.spid.agid.gov.it&
   response_type=code&scope=openid& code_challenge=qWJlMe0xdbXrKxTm72EpH659bUxAxw80&

--- a/docs/common/common_examples.rst
+++ b/docs/common/common_examples.rst
@@ -801,7 +801,7 @@ The following example shows a Metadata policy in the Entity Statement provided b
         "openid_relying_party": {
             "jwks": {
               "keys": [{
-                "subset_of": [{
+                "value": [{
                     "kty": "RSA",
                     "use": "sig",
                     "n": "…",
@@ -884,7 +884,7 @@ The following example shows a Metadata policy in the Entity Statement provided b
     "metadata_policy": {
         "openid_relying_party": {
             "jwks": {
-                "subset_of": [{
+                "value": [{
                     "kty": "RSA",
                     "use": "sig",
                     "n": "…",
@@ -902,7 +902,7 @@ The following example shows a Metadata policy in the Entity Statement provided b
     "metadata_policy": {
         "openid_relying_party": {
             "jwks": {
-                "subset_of": [{
+                "value": [{
                     "kty": "RSA",
                     "use": "sig",
                     "n": "…",

--- a/docs/common/common_examples.rst
+++ b/docs/common/common_examples.rst
@@ -800,15 +800,23 @@ The following example shows a Metadata policy in the Entity Statement provided b
     "metadata_policy": {
         "openid_relying_party": {
             "jwks": {
-              "keys": [{
-                "value": [{
-                    "kty": "RSA",
-                    "use": "sig",
-                    "n": "…",
-                    "e": "AQAB",
-                    "kid": "5NNNoFS3YnC9tjiCaivhWLVUJ3AxwGGz_98uRFaqMEEs"
-                }]
-              }]
+                "value": {
+                    "keys": [
+                        {
+                            "kty": "RSA",
+                            "e": "AQAB",
+                            "use": "sig",
+                            "kid": "....",
+                            "n": "....."
+                        },
+                        {
+                            "kty": "RSA",
+                            "e": "AQAB",
+                            "use": "enc",
+                            "kid": "....",
+                            "n": "....."
+                        }
+                    ]
             },
             "grant_types": {
                 "subset_of": ["authorization_code", "refresh_token"]
@@ -884,14 +892,24 @@ The following example shows a Metadata policy in the Entity Statement provided b
     "metadata_policy": {
         "openid_relying_party": {
             "jwks": {
-                "value": [{
-                    "kty": "RSA",
-                    "use": "sig",
-                    "n": "…",
-                    "e": "AQAB",
-                    "kid": "5NNNoFS3YnC9tjiCaivhWLVUJ3AxwGGz_98uRFaqMEEs"
-                }]
-            }
+                "value": {
+                    "keys": [
+                        {
+                            "kty": "RSA",
+                            "e": "AQAB",
+                            "use": "sig",
+                            "kid": "....",
+                            "n": "....."
+                        },
+                        {
+                            "kty": "RSA",
+                            "e": "AQAB",
+                            "use": "enc",
+                            "kid": "....",
+                            "n": "....."
+                        }
+                    ]
+            },
         }
     }
 
@@ -902,13 +920,23 @@ The following example shows a Metadata policy in the Entity Statement provided b
     "metadata_policy": {
         "openid_relying_party": {
             "jwks": {
-                "value": [{
-                    "kty": "RSA",
-                    "use": "sig",
-                    "n": "…",
-                    "e": "AQAB",
-                    "kid": "5NNNoFS3YnC9tjiCaivhWLVUJ3AxwGGz_98uRFaqMEEs"
-                }]
+                "value": {
+                    "keys": [
+                        {
+                            "kty": "RSA",
+                            "e": "AQAB",
+                            "use": "sig",
+                            "kid": "....",
+                            "n": "....."
+                        },
+                        {
+                            "kty": "RSA",
+                            "e": "AQAB",
+                            "use": "enc",
+                            "kid": "....",
+                            "n": "....."
+                        }
+                    ]
             },
             "revocation_endpoint_auth_methods_supported": {
                 "one_of": ["private_key_jwt"]

--- a/docs/en/authorization_endpoint.rst
+++ b/docs/en/authorization_endpoint.rst
@@ -234,7 +234,7 @@ If the authentication is successful the OpenID Provider (OP) redirects the user 
 
 Authorization Response example:
 
-  .. code-block:: http
+  .. code-block:: 
 
     http://rp-test.it/oidc/rp/callback/?code=a032faf23d986353019ff8eda96cadce2ea1c368f04bf4c5e1759d559dda1c08056c7c4d4e8058cb002a0c8fa9a920272350aa102548523a8aff4ccdb44cb3fa&state=2Ujz3tbBHWQEL4XPFSJ5ANSjkhd7IlfC&iss=http%3A%2F%2Fop-test%2Foidc%2Fop%2F
 

--- a/docs/en/entity_statement.rst
+++ b/docs/en/entity_statement.rst
@@ -97,29 +97,29 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
       *essential = false*
     - |cieid-icon|
   * - **id_token_encrypted_response_enc**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
       *essential = false*
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
     - Operations: *one_of* |br|
@@ -149,29 +149,29 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
       *essential = false*
     - |cieid-icon|
   * - **id_token_encrypted_response_enc**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
       *essential = false*
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
     - Operations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
     - Operations: *one_of* |br|

--- a/docs/en/entity_statement.rst
+++ b/docs/en/entity_statement.rst
@@ -94,7 +94,7 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - |spid-icon| |cieid-icon|
   * - **grant_types**
     - Operations: *subset_of*, *superset_of* |br|
-      Values: MUST be *authorization_code*, *refresh_token* |br|
+      Values: MUST contain *authorization_code*, *refresh_token* |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
@@ -166,7 +166,7 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - **Supported by**
   * - **grant_types**
     - Operations: *subset_of*, *superset_of* |br|
-      Values: MUST be *authorization_code*, *refresh_token* |br|
+      Values: MUST contain *authorization_code*, *refresh_token* |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
@@ -275,23 +275,23 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **response_types_supported**
-    - Operarations: *one_of* |br|
+    - Operarations: *subset_of* |br|
       Values: MUST be *code*. |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **response_modes_supported**
     - Operarations: *subset_of*, *superset_of* |br|
-      Values: MUST be *form_post*, *query*. |br|
+      Values: MUST contain *form_post*, *query*. |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **grant_types_supported**
     - Operarations: *subset_of*, *superset_of* |br|
-      Values: MUST be *refresh_token*, *authorization_code*. |br|
+      Values: MUST contain *refresh_token*, *authorization_code*. |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **acr_values_supported**
     - Operarations: *subset_of*, *superset_of* |br|
-      Values: MUST be |br| *https://www.spid.gov.it/SpidL1*, |br| *https://www.spid.gov.it/SpidL2*, |br| *https://www.spid.gov.it/SpidL3*. |br|
+      Values: MUST contain |br| *https://www.spid.gov.it/SpidL1*, |br| *https://www.spid.gov.it/SpidL2*, |br| *https://www.spid.gov.it/SpidL3*. |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **subject_types_supported**

--- a/docs/en/entity_statement.rst
+++ b/docs/en/entity_statement.rst
@@ -88,7 +88,7 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - **Operations** / **Values**
     - **Supported by**
   * - **jwks**
-    - Operations: *subset_of* |br|
+    - Operations: *value* |br|
       Values: MUST contain the RP JWKS related to the OIDC Core operations.
     - |spid-icon| |cieid-icon|
   * - **grant_types**
@@ -96,27 +96,29 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
       Values: MUST be *authorization_code*, *refresh_token*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
-    - Operations: *subset_of* |br|
+    - Operations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
-    - Operations: *subset_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operations: *one_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = false*
     - |cieid-icon|
   * - **id_token_encrypted_response_enc**
-    - Operations: *subset_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operations: *one_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = false*
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
-    - Operations: *subset_of* |br|
+    - Operations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
-    - Operations: *subset_of* |br|
+    - Operations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
-    - Operations: *subset_of* |br|
+    - Operations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
@@ -146,27 +148,29 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
       Values: MUST be *authorization_code*, *refresh_token*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
-    - Operations: *subset_of* |br|
+    - Operations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
-    - Operations: *subset_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operations: *one_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = false*
     - |cieid-icon|
   * - **id_token_encrypted_response_enc**
-    - Operations: *subset_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operations: *one_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = false*
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
-    - Operations: *subset_of* |br|
+    - Operations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
-    - Operations: *subset_of* |br|
+    - Operations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
-    - Operations: *subset_of* |br|
+    - Operations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
@@ -191,7 +195,7 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - **Operations** / **Values**
     - **Supported by**
   * - **jwks**
-    - Operations: *subset_of* |br|
+    - Operations: *value* |br|
       Values: MUST contain the RP JWKS related to the OIDC Core Operations
     - |spid-icon| |cieid-icon|
 
@@ -209,7 +213,7 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - **Operarations** / **Values**
     - **Supportato da**
   * - **jwks**
-    - Operarations: *subset_of* |br|
+    - Operarations: *value* |br|
       Values: DEVE contenere i JWKS del OP relativi alle Operarations di Core
     - |spid-icon| |cieid-icon|
   * - **revocation_endpoint_auth_methods_supported**
@@ -245,27 +249,27 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
       Values: MUST be *pairwise*.
     - |spid-icon| |cieid-icon|
   * - **id_token_signing_alg_values_supported**
-    - Operarations: *subset_of* |br|
+    - Operarations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encryption_alg_values_supported**
-    - Operarations: *subset_of* |br|
+    - Operarations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encryption_enc_values_supported**
-    - Operarations: *subset_of* |br|
+    - Operarations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_signing_alg_values_supported**
-    - Operarations: *subset_of* |br|
+    - Operarations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encryption_alg_values_supported**
-    - Operarations: *subset_of* |br|
+    - Operarations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encryption_enc_values_supported**
-    - Operarations: *subset_of* |br|
+    - Operarations: *one_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_methods_supported**

--- a/docs/en/entity_statement.rst
+++ b/docs/en/entity_statement.rst
@@ -89,15 +89,18 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - **Supported by**
   * - **jwks**
     - Operations: *value* |br|
-      Values: MUST contain the RP JWKS related to the OIDC Core operations.
+      Values: MUST contain the RP JWKS related to the OIDC Core operations. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **grant_types**
-    - Operations: *subset_of* |br|
-      Values: MUST be *authorization_code*, *refresh_token*
+    - Operations: *subset_of*, *superset_of* |br|
+      Values: MUST be *authorization_code*, *refresh_token* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
     - Operations: *one_of* |br|
@@ -111,23 +114,41 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
     - Operations: *one_of* |br|
-      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
     - Operations: *one_of* |br|
-      Values: MUST be *private_key_jwt*
+      Values: MUST be *private_key_jwt* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **client_registration_types**
-    - Operations: *one_of* |br|
-      Values: MUST be *automatic*
+    - Operations: *subset_of* |br|
+      Values: MUST be *automatic* |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **redirect_uris**
+    - Operations: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **client_id**
+    - Operations: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **response_types**
+    - Operations: *value* |br|
+      Values: MUST be *code* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   
 
@@ -144,12 +165,14 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - **Operations** / **Values**
     - **Supported by**
   * - **grant_types**
-    - Operations: *subset_of* |br|
-      Values: MUST be *authorization_code*, *refresh_token*
+    - Operations: *subset_of*, *superset_of* |br|
+      Values: MUST be *authorization_code*, *refresh_token* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
     - Operations: *one_of* |br|
@@ -163,23 +186,41 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
     - Operations: *one_of* |br|
-      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
     - Operations: *one_of* |br|
-      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+      Values: MUST contain one of the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
     - Operations: *one_of* |br|
-      Values: MUST be *private_key_jwt*
+      Values: MUST be *private_key_jwt* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **client_registration_types**
-    - Operations: *one_of* |br|
-      Values: MUST be *automatic*
+    - Operations: *subset_of* |br|
+      Values: MUST be *automatic* |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **redirect_uris**
+    - Operations: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **client_id**
+    - Operations: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **response_types**
+    - Operations: *value* |br|
+      Values: MUST be *code* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
 
 SA Metadata Policy for RP
@@ -196,7 +237,8 @@ The following claims MUST be considered in the *metadata* parameter of type *ope
     - **Supported by**
   * - **jwks**
     - Operations: *value* |br|
-      Values: MUST contain the RP JWKS related to the OIDC Core Operations
+      Values: MUST contain the RP JWKS related to the OIDC Core Operations |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
 
 
@@ -214,95 +256,147 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - **Supportato da**
   * - **jwks**
     - Operarations: *value* |br|
-      Values: DEVE contenere i JWKS del OP relativi alle Operarations di Core
+      Values: DEVE contenere i JWKS del OP relativi alle Operarations di Core |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **revocation_endpoint_auth_methods_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST be *private_key_jwt*
+    - Operarations: *subset_of* |br|
+      Values: MUST be *private_key_jwt* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **code_challenge_methods_supported**
     - Operarations: *subset_of* |br|
-      Values: MUST be *S256*
+      Values: MUST be *S256* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **scopes_supported**
-    - Operarations: *subset_of* |br|
-      Values: MUST contain *openid*, *offline_access*. CIE id MAY also contain *profile*, *email*.
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST contain *openid*, *offline_access*. CIE id MAY also contain *profile*, *email*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **response_types_supported**
     - Operarations: *one_of* |br|
-      Values: MUST be *code*.
+      Values: MUST be *code*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **response_modes_supported**
-    - Operarations: *subset_of* |br|
-      Values: MUST be *form_post*, *query*.
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST be *form_post*, *query*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **grant_types_supported**
-    - Operarations: *subset_of* |br|
-      Values: MUST be *refresh_token*, *authorization_code*.
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST be *refresh_token*, *authorization_code*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **acr_values_supported**
-    - Operarations: *subset_of* |br|
-      Values: MUST be |br| *https://www.spid.gov.it/SpidL1*, |br| *https://www.spid.gov.it/SpidL2*, |br| *https://www.spid.gov.it/SpidL3*.
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST be |br| *https://www.spid.gov.it/SpidL1*, |br| *https://www.spid.gov.it/SpidL2*, |br| *https://www.spid.gov.it/SpidL3*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **subject_types_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST be *pairwise*.
+    - Operarations: *subset_of* |br|
+      Values: MUST be *pairwise*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_signing_alg_values_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_encryption_alg_values_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_encryption_enc_values_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_signing_alg_values_supported**
-    - Operarations: *one_of* |br|
+    - Operarations: *subset_of*, *superset_of* |br|
       Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
-    - |spid-icon| |cieid-icon|
+    - |spid-icon| |cieid-icon| |br|
+      *essential = true*
   * - **userinfo_encryption_alg_values_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encryption_enc_values_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_methods_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST be *private_key_jwt*
+    - Operarations: *subset_of* |br|
+      Values: MUST be *private_key_jwt* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_signing_alg_values_supported**
-    - Operarations: *subset_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **claims_parameter_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST be *true*
+    - Operarations: *value* |br|
+      Values: MUST be *true* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **request_parameter_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST be *true*
+    - Operarations: *value* |br|
+      Values: MUST be *true* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **authorization_response_iss_parameter_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST be *true*
+    - Operarations: *value* |br|
+      Values: MUST be *true* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **client_registration_types_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST be *automatic*
+    - Operarations: *subset_of* |br|
+      Values: MUST be *automatic* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **request_authentication_methods_supported**
-    - Operarations: *one_of* |br|
-      Values: MUST be *request_object*
+    - Operarations: *value* |br|
+      Values: MUST be *request_object* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **request_authentication_signing_alg_values_supported**
-    - Operarations: *subset_of* |br|
-      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>`
+    - Operarations: *value* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **request_object_signing_alg_values_supported**
+    - Operarations: *subset_of*, *superset_of* |br|
+      Values: MUST contain the algorithms defined in the Section :ref:`Cryptographic Algorithms <supported_algs>` |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **issuer**
+    - Operarations: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **authorization_endpoint**
+    - Operarations: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **token_endpoint**
+    - Operarations: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **userinfo_endpoint**
+    - Operarations: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **introspection_endpoint**
+    - Operarations: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **revocation_endpoint**
+    - Operarations: |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
 
 .. seealso:: 

--- a/docs/en/federation_endpoint.rst
+++ b/docs/en/federation_endpoint.rst
@@ -29,3 +29,14 @@ In addition to the Federation endpoints reported before, the Entities of type **
    (For more details, see `OIDC-FED`_ Section 7.3).
 
 An Entity of type **AA**, in addition to the common Federation endpoints like all the Entities, MUST also include the **trust mark status endpoint** for allowing the dynamic validation of the TMs, released by the AA.
+
+.. admonition:: |cieid-icon|
+
+  Federation endpoint webpaths MUST be defined as follows:
+
+  - \*/.well-known/openid-federation
+  - \*/fetch 
+  - \*/resolve
+  - \*/trust_mark_status
+  - \*/list
+

--- a/docs/en/introspection_endpoint.rst
+++ b/docs/en/introspection_endpoint.rst
@@ -1,5 +1,7 @@
 .. include:: ../common/common_definitions.rst
 
+.. _introspection_endpoint:
+
 Introspection Endpoint
 ----------------------
 

--- a/docs/en/metadata_aa.rst
+++ b/docs/en/metadata_aa.rst
@@ -7,7 +7,7 @@ Attribute Authority Metadata
 An AA MUST publish in its EC a *federation_entity* Metadata and an *oauth_resource* Metadata, if the resources are protected it MUST also publish an *oauth_authorization_server* Metadata.
 
 
-.. code-block:: json
+.. code-block:: 
 
  {
     "metadata":{

--- a/docs/en/metadata_oidc_op.rst
+++ b/docs/en/metadata_oidc_op.rst
@@ -8,7 +8,7 @@ OpenID Connect Provider Metadata (OP)
 An OP MUST publish in its EC a Metadata of type *federation_entity* and a Metadata of type *openid_provider*, as 
 reported in the following example:
 
-.. code-block:: json
+.. code-block:: 
 
  {
     "metadata":{
@@ -159,6 +159,12 @@ The EC of an OP MUST configure a metadata of type **"openid_provider"**, that MU
     - See `OIDC-FED`_ Section 4.2. See signature :ref:`supported_algs`.
     - |spid-icon| |cieid-icon|
 
+..    * - **request_object_encryption_alg_values_supported**
+..      - Until otherwise indicated by AgID, this MUST NOT be included.
+..      - |spid-icon|
+..    * - **request_object_encryption_enc_values_supported**
+..      - Until otherwise indicated by AgID, this MUST NOT be included.
+..      - |spid-icon|
 
 .. warning::
   The OP Metadata of type **"openid_provider"** exposes the claim **jwks** as regulated by OID-FED instead of

--- a/docs/en/metadata_oidc_op.rst
+++ b/docs/en/metadata_oidc_op.rst
@@ -128,12 +128,6 @@ The EC of an OP MUST configure a metadata of type **"openid_provider"**, that MU
   * - **request_object_signing_alg_values_supported**
     - See `OpenID.Discovery#OP_Metadata`_. See signature :ref:`supported_algs`.
     - |spid-icon| |cieid-icon|
-..    * - **request_object_encryption_alg_values_supported**
-..      - Until otherwise indicated by AgID, this MUST NOT be included.
-..      - |spid-icon|
-..    * - **request_object_encryption_enc_values_supported**
-..      - Until otherwise indicated by AgID, this MUST NOT be included.
-..      - |spid-icon|
   * - **token_endpoint_auth_methods_supported**
     - See `OpenID.Discovery#OP_Metadata`_. The supported value is **private_key_jwt**
     - |spid-icon| |cieid-icon|

--- a/docs/en/metadata_oidc_op.rst
+++ b/docs/en/metadata_oidc_op.rst
@@ -159,6 +159,10 @@ The EC of an OP MUST configure a metadata of type **"openid_provider"**, that MU
     - See `OIDC-FED`_ Section 4.2. See signature :ref:`supported_algs`.
     - |spid-icon| |cieid-icon|
 
+.. admonition:: |spid-icon|
+
+  Until otherwise indicated by AgID, the parameters **request_object_encryption_alg_values_supported** e **request_object_encryption_enc_values_supported**, MUST NOT be included in the SPID OP Metadata.
+
 ..    * - **request_object_encryption_alg_values_supported**
 ..      - Until otherwise indicated by AgID, this MUST NOT be included.
 ..      - |spid-icon|

--- a/docs/en/metadata_oidc_rp.rst
+++ b/docs/en/metadata_oidc_rp.rst
@@ -72,7 +72,7 @@ The RP Metadata of type **"openid_relying_party"** MUST contain at least the fol
     - See `OpenID.Registration#ClientMetadata`_. See signature :ref:`supported_algs`.
     - |spid-icon| |cieid-icon| 
   * - **id_token_encrypted_response_alg**
-    - See `OpenID.Registration#ClientMetadata`_. See key encryption :ref:`supported_algs`.
+    - OPTIONAL. If it is contained in the RP Metadata, the ID Token MUST be a nested signed and encrypted JWT. See `OpenID.Registration#ClientMetadata`_. See key encryption :ref:`supported_algs`.
     - |cieid-icon| 
   * - **id_token_encrypted_response_enc**
     - See `OpenID.Registration#ClientMetadata`_. This content encryption is required only if the *id_token_encrypted_response_alg* is given. See key encryption :ref:`supported_algs`.

--- a/docs/en/metadata_oidc_rp.rst
+++ b/docs/en/metadata_oidc_rp.rst
@@ -68,6 +68,9 @@ The RP Metadata of type **"openid_relying_party"** MUST contain at least the fol
   * - **jwks**
     - See `OpenID.Registration#ClientMetadata`_ and `JWK`_.
     - |spid-icon| |cieid-icon| 
+  * - **signed_jwks_uri**
+    - See `OIDC-FED`_.
+    - |spid-icon|
   * - **id_token_signed_response_alg**
     - See `OpenID.Registration#ClientMetadata`_. See signature :ref:`supported_algs`.
     - |spid-icon| |cieid-icon| 
@@ -102,4 +105,12 @@ The RP Metadata of type **"openid_relying_party"** MUST contain at least the fol
 .. note:: 
   The URIs contained in the claim **redirect_uris** MAY also use custom schemas (e.g. myapp://) 
   in order to support mobile applications.
+
+.. admonition:: |cieid-icon|
+
+  The RP Metadata **"openid_relying_party"** MUST use the **jwks** parameter.
+
+.. admonition:: |spid-icon|
+  
+  The RP Metadata **"openid_relying_party"** MUST use the **jwks** or **signed_jwks_uri**.
 

--- a/docs/en/metadata_oidc_rp.rst
+++ b/docs/en/metadata_oidc_rp.rst
@@ -7,7 +7,7 @@ OpenID Connect Relying Party Metadata (RP)
 
 An RP MUST publish in its EC a Metadata of type *federation_entity* and a Metadata of type *openid_relying_party*, as reported in the following example:
 
-.. code-block:: json
+.. code-block:: 
 
  {
     "metadata":{

--- a/docs/en/metadata_oidc_ta_sa.rst
+++ b/docs/en/metadata_oidc_ta_sa.rst
@@ -7,7 +7,7 @@ Trust Anchor (TA) and Intermediate (SA) Metadata
 
 A TA and a SA MUST publish in the EC a Metadata of type *federation_entity*, as reported in the following example:
 
-.. code-block:: json
+.. code-block:: 
 
  {
     "metadata":{

--- a/docs/en/token_endpoint.rst
+++ b/docs/en/token_endpoint.rst
@@ -174,7 +174,7 @@ UserInfo endpoint to get user attributes.
 
 **Access Token header and payload example:**
 
-.. code-block:: json
+.. code-block:: 
 
   {
     "alg": "RS256",
@@ -246,7 +246,7 @@ The claims available in the *ID Token* are given below.
 
 **Example of header and payload of an ID Token:**
 
-.. code-block:: json
+.. code-block:: 
 
 
   {

--- a/docs/en/token_endpoint.rst
+++ b/docs/en/token_endpoint.rst
@@ -93,7 +93,7 @@ The claims that MUST be included in the *Token Request* are given below.
      - |spid-icon| |cieid-icon|
    * - **client_assertion_type**
      - It must get the following value: |br|
-       **urn:ietf:params:oauth:client-assertion-type:jwtbearer**.
+       **urn:ietf:params:oauth:client-assertion-type:jwt-bearer**.
      - |spid-icon| |cieid-icon|
    * - **code**
      - Authorization code returned in the Authentication Response. Required only if **grant_type** is **authorization_code**.

--- a/docs/en/token_endpoint.rst
+++ b/docs/en/token_endpoint.rst
@@ -335,8 +335,11 @@ The *Refresh Token* MUST be a signed JWT containing at least the following param
   * - **iss** 
     - It MUST be an HTTPS URL that uniquely identifies the OP. The RP MUST verify that this value matches the called OP.
     - |spid-icon| |cieid-icon|
-  * - **aud** 
+  * - **client_id** 
     - It MUST match the value client_id. The RP MUST verify that this value matches its client ID.
+    - |spid-icon| |cieid-icon|
+  * - **aud** 
+    - It MUST contain the OP *Token Endpoint*.
     - |spid-icon| |cieid-icon|
   * - **iat** 
     - UNIX Timestamp with the time of JWT issuance, coded as NumericDate as indicated in :rfc:`7519`.

--- a/docs/en/token_endpoint.rst
+++ b/docs/en/token_endpoint.rst
@@ -183,10 +183,10 @@ UserInfo endpoint to get user attributes.
   }
   .
   {
-    "iss":"https://op.spid.agid.gov.it/",
+    "iss":"https://op.spid.agid.gov.it",
     "sub": "9sd798asd98asui23hiuds89y798sfyg",
     "aud": [
-    "https://rp.spid.example.it"
+    "https://op.spid.agid.gov.it/userinfo"
     ],
     "client_id": "https://rp.spid.example.it",
     "scope": "openid",
@@ -213,7 +213,7 @@ UserInfo endpoint to get user attributes.
      - It MUST contain a HTTPS URL that uniquely identifies the RP. 
      - |spid-icon| |cieid-icon|
    * - **aud** 
-     - It MUST match the value *client_id*. The RP MUST verify that this value matches its client ID.
+     - It MUST contain a list of Resource Servers referring to token consuming party. It MUST contain at least the *UserInfo Endpoint*. 
      - |spid-icon| |cieid-icon|
    * - **scope** 
      - The OP SHOULD add the *scope* parameter as defined in :rfc:`9068` Section 2.2.3. It MUST match the value in the authentication request.

--- a/docs/en/token_endpoint.rst
+++ b/docs/en/token_endpoint.rst
@@ -185,9 +185,7 @@ UserInfo endpoint to get user attributes.
   {
     "iss":"https://op.spid.agid.gov.it",
     "sub": "9sd798asd98asui23hiuds89y798sfyg",
-    "aud": [
-    "https://op.spid.agid.gov.it/userinfo"
-    ],
+    "aud": "https://op.spid.agid.gov.it/userinfo",
     "client_id": "https://rp.spid.example.it",
     "scope": "openid",
     "jti": "9ea42af0-594c-4486-9602-8a1f8dde42d3",

--- a/docs/en/userinfo_endpoint.rst
+++ b/docs/en/userinfo_endpoint.rst
@@ -18,7 +18,7 @@ Request
   The UserInfo Endpoint MUST support the method HTTP GET and HTTP POST :rfc:`2616` and MUST accept and validate the Access Token sent in the Authorization field of the Header, whose type is Bearer :rfc:`6750`.
 
 
-.. code-block:: http
+.. code-block:: 
 
  GET https://op.spid.agid.gov.it/userinfo
   Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6ImRCNjdnTDdja ...

--- a/docs/it/authorization_endpoint.rst
+++ b/docs/it/authorization_endpoint.rst
@@ -26,7 +26,7 @@ Mediante il metodo **GET** i parametri DEVONO essere trasmessi utilizzando la *Q
 
 Di seguito i parametri obbligatori nella richiesta di autenticazione *HTTP*.
 
-.. _tabella_parametri_authz_req: Authorization request
+.. _tabella_parametri_authz_req:
 
 .. list-table:: 
   :widths: 20 60 20
@@ -85,10 +85,10 @@ Il payload del **JWT** contiene i seguenti parametri obbligatori.
      - Vedi `OpenID.Registration`_. DEVE essere valorizzato con un HTTPS URL che identifica univocamente il RP.
      - |spid-icon| |cieid-icon|
    * - **code_challenge**
-     - Come definito nella  :ref:`Tabella dei parametri HTTP <tabella_parametri_http_req>`.
+     - Come definito nella  :ref:`Tabella dei parametri HTTP <tabella_parametri_authz_req>`.
      - |spid-icon| |cieid-icon|
    * - **code_challenge_method**
-     - Come definito nella  :ref:`Tabella dei parametri HTTP <tabella_parametri_http_req>`.
+     - Come definito nella  :ref:`Tabella dei parametri HTTP <tabella_parametri_authz_req>`.
      - |spid-icon| |cieid-icon|
    * - **nonce**
      - Vedi `OpenID.Core#AuthRequest`_. DEVE essere una stringa casuale di almeno 32 caratteri alfanumerici. Questo valore sarà restituito nell'ID Token fornito dal Token Endpoint, in modo da consentire al client di verificare che sia uguale a quello inviato nella richiesta di autenticazione.
@@ -111,7 +111,7 @@ Il payload del **JWT** contiene i seguenti parametri obbligatori.
      - Vedi `OpenID.Core#AuthRequest`_. Come definito dal parametro **response_types_supported** nel :ref:`Metadata OP <MetadataOP>`.
      - |spid-icon| |cieid-icon|
    * - **scope**
-     - Come definito nella  :ref:`Tabella dei parametri HTTP <tabella_parametri_http_req>`.
+     - Come definito nella  :ref:`Tabella dei parametri HTTP <tabella_parametri_authz_req>`.
      - |spid-icon| |cieid-icon|
    * - **acr_values**
      - Vedi `OpenID.Core#AuthRequest`_. Come definito dal parametro **acr_values_supported** nel :ref:`Metadata OP <MetadataOP>`.
@@ -233,7 +233,7 @@ reindirizza l'utente aggiungendo i seguenti parametri obbligatori come query par
 
 Esempio di Authorization Response dell'OP:
 
-  .. code-block:: http
+  .. code-block:: 
 
     http://rp-test.it/oidc/rp/callback/?code=a032faf23d986353019ff8eda96cadce2ea1c368f04bf4c5e1759d559dda1c08056c7c4d4e8058cb002a0c8fa9a920272350aa102548523a8aff4ccdb44cb3fa&state=2Ujz3tbBHWQEL4XPFSJ5ANSjkhd7IlfC&iss=http%3A%2F%2Fop-test%2Foidc%2Fop%2F
 

--- a/docs/it/entity_configuration.rst
+++ b/docs/it/entity_configuration.rst
@@ -110,7 +110,7 @@ Gli EC di un TA, in aggiunta ai claim comuni a tutti i partecipanti, contengono 
      - JSON Object che descrive un insieme di vincoli della Trust Chain e che DEVE contenere l'attributo **max_path_length**. Rappresenta il numero massimo di SA tra una Foglia e il TA.
        PUÒ anche contenere il claim **allowed_leaf_entity_types**, che restringe i tipi di Entità riconoscobili come suoi discendenti.
      - |spid-icon| |cieid-icon|
-   * - **trust_marks_issuers**
+   * - **trust_mark_issuers**
      - JSON Array che indica quali autorità sono considerate attendibili nella Federazione per l'emissione di specifici TM, questi assegnati mediante il proprio identificativo univoco.
      - |spid-icon| |cieid-icon|
 

--- a/docs/it/entity_statement.rst
+++ b/docs/it/entity_statement.rst
@@ -89,29 +89,29 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
       *essential = false*
     - |cieid-icon|
   * - **id_token_encrypted_response_enc**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
       *essential = false*
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
     - Operazioni: *one_of* |br|
@@ -143,7 +143,7 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
     - Operazioni: *one_of* |br|
@@ -152,20 +152,20 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - |cieid-icon|
   * - **id_token_encrypted_response_enc**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
       *essential = false*
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
     - Operazioni: *one_of* |br|

--- a/docs/it/entity_statement.rst
+++ b/docs/it/entity_statement.rst
@@ -86,7 +86,7 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - |spid-icon| |cieid-icon|
   * - **grant_types**
     - Operazioni: *subset_of*, *super_set* |br|
-      Valori: DEVE essere *authorization_code* e *refresh_token* |br|
+      Valori: DEVE contenere *authorization_code* e *refresh_token* |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
@@ -160,7 +160,7 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - **Supportato da**
   * - **grant_types**
     - Operazioni: *subset_of*, *superset_of* |br|
-      Valori: DEVE essere *authorization_code* e *refresh_token* |br|
+      Valori: DEVE contenere *authorization_code* e *refresh_token* |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
@@ -270,23 +270,23 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **response_types_supported**
-    - Operazioni: *one_of* |br|
+    - Operazioni: *subset_of* |br|
       Valori: DEVE essere *code*. |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **response_modes_supported**
     - Operazioni: *subset_of*, *superset_of* |br|
-      Valori: DEVE essere *form_post*, *query*. |br|
+      Valori: DEVE contenere *form_post*, *query*. |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **grant_types_supported**
     - Operazioni: *subset_of*, *superset_of* |br|
-      Valori: DEVE essere *refresh_token*, *authorization_code*. |br|
+      Valori: DEVE contenere *refresh_token*, *authorization_code*. |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **acr_values_supported**
     - Operazioni: *subset_of*, *superset_of* |br|
-      Valori: DEVE essere |br| *https://www.spid.gov.it/SpidL1*, |br| *https://www.spid.gov.it/SpidL2*, |br| *https://www.spid.gov.it/SpidL3*.  |br|
+      Valori: DEVE contenere |br| *https://www.spid.gov.it/SpidL1*, |br| *https://www.spid.gov.it/SpidL2*, |br| *https://www.spid.gov.it/SpidL3*.  |br|
       *essential = true*
     - |spid-icon| |cieid-icon|
   * - **subject_types_supported**

--- a/docs/it/entity_statement.rst
+++ b/docs/it/entity_statement.rst
@@ -80,7 +80,7 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - **Operazioni** / **Valori**
     - **Supportato da**
   * - **jwks**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *value* |br|
       Valori: DEVE contenere i JWKS del RP relativi alle operazioni di Core
     - |spid-icon| |cieid-icon|
   * - **grant_types**
@@ -88,27 +88,29 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
       Valori: DEVE essere *authorization_code* e *refresh_token*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+    - Operazioni: *one_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = false*
     - |cieid-icon|
   * - **id_token_encrypted_response_enc**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+    - Operazioni: *one_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = false*
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
@@ -140,27 +142,29 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
       Valori: DEVE essere *authorization_code* e *refresh_token*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+    - Operazioni: *one_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = false*
     - |cieid-icon|
   * - **id_token_encrypted_response_enc**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+    - Operazioni: *one_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = false*
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
@@ -186,7 +190,7 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - **Operazioni** / **Valori**
     - **Supportato da**
   * - **jwks**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *value* |br|
       Valori: DEVE contenere i JWKS del RP relativi alle operazioni di Core
     - |spid-icon| |cieid-icon|
 
@@ -204,7 +208,7 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - **Operazioni** / **Valori**
     - **Supportato da**
   * - **jwks**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *value* |br|
       Valori: DEVE contenere i JWKS del OP relativi alle operazioni di Core
     - |spid-icon| |cieid-icon|
   * - **revocation_endpoint_auth_methods_supported**
@@ -240,27 +244,27 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
       Valori: DEVE essere *pairwise*.
     - |spid-icon| |cieid-icon|
   * - **id_token_signing_alg_values_supported**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encryption_alg_values_supported**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **id_token_encryption_enc_values_supported**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_signing_alg_values_supported**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encryption_alg_values_supported**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **userinfo_encryption_enc_values_supported**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_methods_supported**
@@ -268,7 +272,7 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
       Valori: DEVE essere *private_key_jwt*
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_signing_alg_values_supported**
-    - Operazioni: *subset_of* |br|
+    - Operazioni: *one_of* |br|
       Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
     - |spid-icon| |cieid-icon|
   * - **claims_parameter_supported**

--- a/docs/it/entity_statement.rst
+++ b/docs/it/entity_statement.rst
@@ -81,15 +81,18 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - **Supportato da**
   * - **jwks**
     - Operazioni: *value* |br|
-      Valori: DEVE contenere i JWKS del RP relativi alle operazioni di Core
+      Valori: DEVE contenere i JWKS del RP relativi alle operazioni di Core |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **grant_types**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE essere *authorization_code* e *refresh_token*
+    - Operazioni: *subset_of*, *super_set* |br|
+      Valori: DEVE essere *authorization_code* e *refresh_token* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
     - Operazioni: *one_of* |br|
@@ -103,23 +106,41 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
     - Operazioni: *one_of* |br|
-      Valori: DEVE essere *private_key_jwt*
+      Valori: DEVE essere *private_key_jwt* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **client_registration_types**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE essere *automatic*
+    - Operazioni: *subset_of* |br|
+      Valori: DEVE essere *automatic* |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **redirect_uris**
+    - Operazioni: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **client_id**
+    - Operazioni: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **response_types**
+    - Operazioni: *value* |br|
+      Valori: DEVE essere *code* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   
 
@@ -138,12 +159,14 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - **Operazioni** / **Valori**
     - **Supportato da**
   * - **grant_types**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE essere *authorization_code* e *refresh_token*
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE essere *authorization_code* e *refresh_token* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_signed_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_encrypted_response_alg**
     - Operazioni: *one_of* |br|
@@ -157,23 +180,41 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - |cieid-icon|
   * - **userinfo_signed_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_alg**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encrypted_response_enc**
     - Operazioni: *one_of* |br|
-      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+      Valori: DEVE contenere uno degli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_method**
     - Operazioni: *one_of* |br|
-      Valori: DEVE essere *private_key_jwt*
+      Valori: DEVE essere *private_key_jwt* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **client_registration_types**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE essere *automatic*
+    - Operazioni: *subset_of* |br|
+      Valori: DEVE essere *automatic* |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **redirect_uris**
+    - Operazioni: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **client_id**
+    - Operazioni: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **response_types**
+    - Operazioni: *value* |br|
+      Valori: DEVE essere *code* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
 
 
@@ -191,7 +232,8 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - **Supportato da**
   * - **jwks**
     - Operazioni: *value* |br|
-      Valori: DEVE contenere i JWKS del RP relativi alle operazioni di Core
+      Valori: DEVE contenere i JWKS del RP relativi alle operazioni di Core |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
 
 
@@ -209,95 +251,147 @@ Di seguito vengono riportati i claim che DEVONO essere considerati nel parametro
     - **Supportato da**
   * - **jwks**
     - Operazioni: *value* |br|
-      Valori: DEVE contenere i JWKS del OP relativi alle operazioni di Core
+      Valori: DEVE contenere i JWKS del OP relativi alle operazioni di Core |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **revocation_endpoint_auth_methods_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE essere *private_key_jwt*
+    - Operazioni: *subset_of* |br|
+      Valori: DEVE essere *private_key_jwt* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **code_challenge_methods_supported**
     - Operazioni: *subset_of* |br|
-      Valori: DEVE essere *S256*
+      Valori: DEVE essere *S256* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **scopes_supported**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE contenere *openid*, *offline_access*. Per CIE id PUÒ contenere anche *profile*, *email*.
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE contenere *openid*, *offline_access*. Per CIE id PUÒ contenere anche *profile*, *email*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **response_types_supported**
     - Operazioni: *one_of* |br|
-      Valori: DEVE essere *code*.
+      Valori: DEVE essere *code*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **response_modes_supported**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE essere *form_post*, *query*.
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE essere *form_post*, *query*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **grant_types_supported**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE essere *refresh_token*, *authorization_code*.
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE essere *refresh_token*, *authorization_code*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **acr_values_supported**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE essere |br| *https://www.spid.gov.it/SpidL1*, |br| *https://www.spid.gov.it/SpidL2*, |br| *https://www.spid.gov.it/SpidL3*.
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE essere |br| *https://www.spid.gov.it/SpidL1*, |br| *https://www.spid.gov.it/SpidL2*, |br| *https://www.spid.gov.it/SpidL3*.  |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **subject_types_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE essere *pairwise*.
+    - Operazioni: *subset_of* |br|
+      Valori: DEVE essere *pairwise*. |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_signing_alg_values_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **id_token_encryption_alg_values_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
-    - |spid-icon| |cieid-icon|
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
+    - |cieid-icon|
   * - **id_token_encryption_enc_values_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
-    - |spid-icon| |cieid-icon|
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
+    - |cieid-icon|
   * - **userinfo_signing_alg_values_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encryption_alg_values_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **userinfo_encryption_enc_values_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_methods_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE essere *private_key_jwt*
+    - Operazioni: *subset_of* |br|
+      Valori: DEVE essere *private_key_jwt* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **token_endpoint_auth_signing_alg_values_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **claims_parameter_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE essere *true*
+    - Operazioni: *value* |br|
+      Valori: DEVE essere *true* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **request_parameter_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE essere *true*
+    - Operazioni: *value* |br|
+      Valori: DEVE essere *true* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **authorization_response_iss_parameter_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE essere *true*
+    - Operazioni: *value* |br|
+      Valori: DEVE essere *true* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **client_registration_types_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE essere *automatic*
+    - Operazioni: *subset_of* |br|
+      Valori: DEVE essere *automatic* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **request_authentication_methods_supported**
-    - Operazioni: *one_of* |br|
-      Valori: DEVE essere *request_object*
+    - Operazioni: *value* |br|
+      Valori: DEVE essere *request_object* |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
   * - **request_authentication_signing_alg_values_supported**
-    - Operazioni: *subset_of* |br|
-      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>`
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **request_object_signing_alg_values_supported**
+    - Operazioni: *subset_of*, *superset_of* |br|
+      Valori: DEVE contenere gli algoritmi definiti nella Sezione :ref:`Algoritmi Crittografici <supported_algs>` |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **issuer**
+    - Operazioni: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **authorization_endpoint**
+    - Operazioni: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **token_endpoint**
+    - Operazioni: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **userinfo_endpoint**
+    - Operazioni: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **introspection_endpoint**
+    - Operazioni: |br|
+      *essential = true*
+    - |spid-icon| |cieid-icon|
+  * - **revocation_endpoint**
+    - Operazioni: |br|
+      *essential = true*
     - |spid-icon| |cieid-icon|
 
 .. seealso:: 

--- a/docs/it/federation_endpoint.rst
+++ b/docs/it/federation_endpoint.rst
@@ -21,3 +21,15 @@ Le Entità di tipo **TA** o **SA** DEVONO offrire i seguenti endpoint, in aggiun
  - **entity listing endpoint**: fornisce la lista delle entità discendenti registrate presso il TA o un SA (per maggiori dettagli vedi `OIDC-FED`_ Section 7.3)
 
 Un'entità di tipo **AA**, oltre agli endpoint di Federazione comuni a tutte le entità, DEVE riportare anche il **trust mark status endpoint** per consentire la validazione dinamica dei TM rilasciati dall'AA.
+
+.. admonition:: |cieid-icon|
+
+  I webpath degli endpoint di Federazione DEVONO essere definiti nel modo seguente:
+
+  - \*/.well-known/openid-federation
+  - \*/fetch 
+  - \*/resolve
+  - \*/trust_mark_status
+  - \*/list
+
+

--- a/docs/it/la_federazione_delle_identita.rst
+++ b/docs/it/la_federazione_delle_identita.rst
@@ -34,7 +34,7 @@ Configurazione della Federazione
 
 La configurazione della Federazione è pubblicata dal Trust Anchor all'interno della sua :ref:`Entity Configuration<entity_configuration_ta>`, disponibile presso un web path ben noto e corrispondente a **.well-known/openid-federation**.
 
-Tutti i partecipanti DEVONO ottenere, prima della fase di esercizio, la configurazione della Federazione e mantenerla aggiornata su base giornaliera. All'interno della configurazione della Federazione sono pubblicate le chiave pubbliche del Trust Anchor usate per le operazioni di firma, il numero massimo di Intermediari consentiti tra una Foglia e il Trust Anchor (**max_path length**) e le autorità abilitate all'emissione dei Trust Mark (**trust_marks_issuers**).
+Tutti i partecipanti DEVONO ottenere, prima della fase di esercizio, la configurazione della Federazione e mantenerla aggiornata su base giornaliera. All'interno della configurazione della Federazione sono pubblicate le chiave pubbliche del Trust Anchor usate per le operazioni di firma, il numero massimo di Intermediari consentiti tra una Foglia e il Trust Anchor (**max_path length**) e le autorità abilitate all'emissione dei Trust Mark (**trust_mark_issuers**).
 
 
 Si veda qui un esempio non normativo di :ref:`Entity Configuration response Trust Anchor<Esempio_EN1.4>`

--- a/docs/it/metadata_aa.rst
+++ b/docs/it/metadata_aa.rst
@@ -7,7 +7,7 @@ Metadata Attribute Authority
 Una AA DEVE pubblicare, all'interno del suo EC, un Metadata *federation_entity* e un Metadata *oauth_resource* e, se le risorse sono protette, DEVE anche pubblicare un Metadata *oauth_authorization_server*.
 
 
-.. code-block:: json
+.. code-block:: 
 
  {
     "metadata":{

--- a/docs/it/metadata_oidc_op.rst
+++ b/docs/it/metadata_oidc_op.rst
@@ -7,7 +7,7 @@ OpenID Connect Provider Metadata (OP)
 
 Un OP DEVE pubblicare all'interno del suo EC un Metadata da *federation_entity* e uno da *openid_provider* come riportato nel seguente esempio:
 
-.. code-block:: json
+.. code-block:: 
 
  {
     "metadata":{
@@ -159,6 +159,12 @@ L'EC di un OP DEVE configurare un metadata di tipo **"openid_provider"** DEVE co
     - Vedi `OIDC-FED`_ Section 4.2. Vedi signature :ref:`supported_algs`.
     - |spid-icon| |cieid-icon|
 
+..    * - **request_object_encryption_alg_values_supported**
+..      - Fino a diversa indicazione di AgID, non deve essere incluso.
+..      - |spid-icon|
+..    * - **request_object_encryption_enc_values_supported**
+..      - Fino a diversa indicazione di AgID, non deve essere incluso.
+..      - |spid-icon|
 
 .. warning::
   Il Metadata **"openid_provider"** DEVE adottare il parametro **jwks** o **signed_jwks_uri** come normato da OID-FED invece del parametro **jwks_uri** come richiesto in `OpenID.Discovery#OP_Metadata`_. 

--- a/docs/it/metadata_oidc_op.rst
+++ b/docs/it/metadata_oidc_op.rst
@@ -128,12 +128,6 @@ L'EC di un OP DEVE configurare un metadata di tipo **"openid_provider"** DEVE co
   * - **request_object_signing_alg_values_supported**
     - Vedi `OpenID.Discovery#OP_Metadata`_. Vedi signature :ref:`supported_algs`.
     - |spid-icon| |cieid-icon|
-..    * - **request_object_encryption_alg_values_supported**
-..      - Fino a diversa indicazione di AgID, non deve essere incluso.
-..      - |spid-icon|
-..    * - **request_object_encryption_enc_values_supported**
-..      - Fino a diversa indicazione di AgID, non deve essere incluso.
-..      - |spid-icon|
   * - **token_endpoint_auth_methods_supported**
     - Vedi `OpenID.Discovery#OP_Metadata`_. Il valore supportato è **private_key_jwt**
     - |spid-icon| |cieid-icon|

--- a/docs/it/metadata_oidc_op.rst
+++ b/docs/it/metadata_oidc_op.rst
@@ -159,6 +159,10 @@ L'EC di un OP DEVE configurare un metadata di tipo **"openid_provider"** DEVE co
     - Vedi `OIDC-FED`_ Section 4.2. Vedi signature :ref:`supported_algs`.
     - |spid-icon| |cieid-icon|
 
+.. admonition:: |spid-icon|
+
+  Fino a diversa indicazione di AgID, i parametri **request_object_encryption_alg_values_supported** e **request_object_encryption_enc_values_supported**, NON DEVONO essere inclusi nel Metadata OP SPID.
+
 ..    * - **request_object_encryption_alg_values_supported**
 ..      - Fino a diversa indicazione di AgID, non deve essere incluso.
 ..      - |spid-icon|

--- a/docs/it/metadata_oidc_rp.rst
+++ b/docs/it/metadata_oidc_rp.rst
@@ -73,7 +73,7 @@ Il Metadata di tipo **"openid_relying_party"** DEVE contenere almeno i seguenti 
     - Vedi `OpenID.Registration#ClientMetadata`_. Vedi signature :ref:`supported_algs`.
     - |spid-icon| |cieid-icon| 
   * - **id_token_encrypted_response_alg**
-    - Vedi `OpenID.Registration#ClientMetadata`_. Vedi key encryption :ref:`supported_algs`.
+    - OPZIONALE. Se presente, l'OP DEVE restituire l'ID Token firmato e cifrato. Vedi `OpenID.Registration#ClientMetadata`_. Vedi key encryption :ref:`supported_algs`.
     - |cieid-icon| 
   * - **id_token_encrypted_response_enc**
     - Vedi `OpenID.Registration#ClientMetadata`_. Obbligatorio solo nel caso sia presente anche il parametro *id_token_encrypted_response_alg*. Vedi content encryption :ref:`supported_algs`.

--- a/docs/it/metadata_oidc_rp.rst
+++ b/docs/it/metadata_oidc_rp.rst
@@ -69,6 +69,9 @@ Il Metadata di tipo **"openid_relying_party"** DEVE contenere almeno i seguenti 
   * - **jwks**
     - Vedi `OpenID.Registration#ClientMetadata`_ e `JWK`_.
     - |spid-icon| |cieid-icon| 
+  * - **signed_jwks_uri**
+    - Vedi `OIDC-FED`_.
+    - |spid-icon|
   * - **id_token_signed_response_alg**
     - Vedi `OpenID.Registration#ClientMetadata`_. Vedi signature :ref:`supported_algs`.
     - |spid-icon| |cieid-icon| 
@@ -102,4 +105,12 @@ Il Metadata di tipo **"openid_relying_party"** DEVE contenere almeno i seguenti 
 
 .. note:: 
   Gli URI presenti nel parametro **redirect_uris** POSSONO anche usare eventuali schemi custom (ad es. myapp://) al fine di supportare applicazioni mobili.
+
+.. admonition:: |cieid-icon|
+  
+  Il Metadata **"openid_relying_party"** DEVE adottare il parametro **jwks**.
+
+.. admonition:: |spid-icon|
+
+  Il Metadata **"openid_relying_party"** DEVE adottare il parametro **jwks** o **signed_jwks_uri**.
 

--- a/docs/it/metadata_oidc_rp.rst
+++ b/docs/it/metadata_oidc_rp.rst
@@ -7,7 +7,7 @@ OpenID Connect Relying Party Metadata (RP)
 
 Un RP DEVE pubblicare all'interno del suo EC un Metadata di tipo *federation_entity* e uno di tipo *openid_relying_party* come riportato nel seguente esempio:
 
-.. code-block:: json
+.. code-block:: 
 
  {
     "metadata":{

--- a/docs/it/metadata_oidc_ta_sa.rst
+++ b/docs/it/metadata_oidc_ta_sa.rst
@@ -7,7 +7,7 @@ Metadata di Trust Anchor (TA) e Intermediari (SA)
 
 Un TA e un SA DEVONO pubblicare all'interno del loro EC un Metadata da *federation_entity* come riportato nel seguente esempio:
 
-.. code-block:: json
+.. code-block:: 
 
  {
     "metadata":{

--- a/docs/it/token_endpoint.rst
+++ b/docs/it/token_endpoint.rst
@@ -327,8 +327,11 @@ Il *Refresh Token* DEVE essere rilasciato in formato JWT, firmato, e contenere a
    * - **iss** 
      - DEVE essere valorizzato con un HTTPS URL che identifica univocamente l'OP. Il RP DEVE verificare che questo valore corrisponda all'OP chiamato.
      - |spid-icon| |cieid-icon|
-   * - **aud** 
+   * - **client_id** 
      - DEVE coincidere con il valore *client_id*. Il RP DEVE verificare che questo valore corrisponda al proprio client ID.
+     - |spid-icon| |cieid-icon|
+   * - **aud** 
+     - DEVE contenere il *Token Endpoint* dell'OP.
      - |spid-icon| |cieid-icon|
    * - **iat** 
      - UNIX Timestamp con l'istante di generazione del JWT, codificato come NumericDate come indicato in :rfc:`7519`

--- a/docs/it/token_endpoint.rst
+++ b/docs/it/token_endpoint.rst
@@ -185,9 +185,7 @@ Di seguito i claim che compongono l'Access Token.
   {
     "iss":"https://op.spid.agid.gov.it",
     "sub": "9sd798asd98asui23hiuds89y798sfyg",
-    "aud": [
-    "https://op.spid.agid.gov.it/userinfo"
-    ],
+    "aud": "https://op.spid.agid.gov.it/userinfo",
     "client_id": "https://rp.spid.example.it",
     "scope": "openid",
     "jti": "9ea42af0-594c-4486-9602-8a1f8dde42d3",

--- a/docs/it/token_endpoint.rst
+++ b/docs/it/token_endpoint.rst
@@ -31,7 +31,7 @@ Di seguito i claim che DEVONO essere inseriti nella *Token Request*.
 
 **Esempio di richiesta con authorization code (caso 1)**
 
-  .. code-block:: json
+  .. code-block:: 
 
     POST /token HTTP/1.1
     Host: https://op.spid.agid.gov.it
@@ -52,7 +52,7 @@ Di seguito i claim che DEVONO essere inseriti nella *Token Request*.
 
 **Esempio di richiesta con Refresh Token (caso 2):**
 
-  .. code-block:: json
+  .. code-block:: 
 
     POST /token HTTP/1.1
     Host: https://op.spid.agid.gov.it
@@ -174,7 +174,7 @@ Di seguito i claim che compongono l'Access Token.
 
 **Esempio del contenuto di intestazione di payload di un Access Token:**
 
-.. code-block:: json
+.. code-block:: 
 
   {
     "alg": "RS256",
@@ -241,7 +241,7 @@ Di seguito i claim disponibili nell'ID Token.
 
  **Esempio del contenuto di intestazione e di payload di un ID Token:**
 
-.. code-block:: json
+.. code-block:: 
 
   {
     "alg": "RS256",

--- a/docs/it/token_endpoint.rst
+++ b/docs/it/token_endpoint.rst
@@ -183,10 +183,10 @@ Di seguito i claim che compongono l'Access Token.
   }
   .
   {
-    "iss":"https://op.spid.agid.gov.it/",
+    "iss":"https://op.spid.agid.gov.it",
     "sub": "9sd798asd98asui23hiuds89y798sfyg",
     "aud": [
-    "https://rp.spid.example.it"
+    "https://op.spid.agid.gov.it/userinfo"
     ],
     "client_id": "https://rp.spid.example.it",
     "scope": "openid",
@@ -213,7 +213,7 @@ Di seguito i claim che compongono l'Access Token.
      - DEVE essere valorizzato con un HTTPS URL che identifica univocamente il RP.  
      - |spid-icon| |cieid-icon|
    * - **aud** 
-     - DEVE coincidere con il valore *client_id*. Il RP DEVE verificare che questo valore corrisponda al proprio client ID.
+     - DEVE contenere un elenco di Resource Server che consumano l'AT. DEVE contenere almeno lo *UserInfo Endpoint*.
      - |spid-icon| |cieid-icon|
    * - **scope** 
      - L'OP DOVREBBE inserire il parametro *scope* come previsto in :rfc:`9068` Sezione 2.2.3. DEVE coincidere con il valore presente in fase di richiesta di autenticazione.

--- a/docs/it/token_endpoint.rst
+++ b/docs/it/token_endpoint.rst
@@ -93,7 +93,7 @@ Di seguito i claim che DEVONO essere inseriti nella *Token Request*.
      - |spid-icon| |cieid-icon|
    * - **client_assertion_type**
      - Deve assumere il seguente valore: |br|
-       **urn:ietf:params:oauth:client-assertion-type:jwtbearer**
+       **urn:ietf:params:oauth:client-assertion-type:jwt-bearer**
      - |spid-icon| |cieid-icon|
    * - **code**
      - Codice di autorizzazione restituito nell'Authentication response. Obbligatorio solo se **grant_type** è **authorization_code**

--- a/docs/it/trust_marks.rst
+++ b/docs/it/trust_marks.rst
@@ -11,14 +11,14 @@ Lo scopo principale dei TM è quello di esporre alcune informazioni non richiest
 
 Esempi tipici includono il codice di identificazione nazionale o internazionale dell'entità (Codice Fiscale, IPA Code, Partita IVA, VAT Number), i contatti istituzionali e altro, come definito in `OIDC-FED`_. Ulteriori dati possono essere aggiunti dal soggetto che li emette.
 
-I TM sono emessi e firmati, durante il processo di registrazione di una nuova entità di tipo Foglia (Onboarding), dal (TA) o suoi Intermediari (SA) o da Gestori Qualificati di Attributi (AA), se definiti all'interno dell'attributo **trust_marks_issuers**, pubblicato all'interno dell'Entity Configuration del TA. 
+I TM sono emessi e firmati, durante il processo di registrazione di una nuova entità di tipo Foglia (Onboarding), dal (TA) o suoi Intermediari (SA) o da Gestori Qualificati di Attributi (AA), se definiti all'interno dell'attributo **trust_mark_issuers**, pubblicato all'interno dell'Entity Configuration del TA. 
 
-Di seguito un esempio non normativo dell'oggetto **trust_marks_issuers** all'interno della Entity Configuration del TA.
+Di seguito un esempio non normativo dell'oggetto **trust_mark_issuers** all'interno della Entity Configuration del TA.
 
 .. code-block:: json
 
  {
-     "trust_marks_issuers":{
+     "trust_mark_issuers":{
          "https://registry.agid.gov.it/openid_relying_party/public/":[
              "https://registry.spid.agid.gov.it/",
              "https://public.intermediate.spid.it/"
@@ -35,7 +35,7 @@ Ogni entità partecipante DEVE esporre nella propria configurazione (EC) i TM ri
 
 Nello scenario CIE / SPID, un TM viene firmato dal TA **MinInterno** / **Agid** o loro Intermediari (SA) o Gestori Qualificati di Attributi (AA). 
 
-Il TA definisce i soggetti abilitati all'emissione dei TM riconoscibili all'interno della Federazione, mediante il claim **trust_marks_issuers**, presente all'interno del proprio Entity Configuration. Il valore dell'attributo **trust_marks_issuers** è composto da un oggetto JSON avente come chiavi gli identificativi dei TM e come valori la lista degli identificativi (URL) delle entità abilitate ad emetterli.
+Il TA definisce i soggetti abilitati all'emissione dei TM riconoscibili all'interno della Federazione, mediante il claim **trust_mark_issuers**, presente all'interno del proprio Entity Configuration. Il valore dell'attributo **trust_mark_issuers** è composto da un oggetto JSON avente come chiavi gli identificativi dei TM e come valori la lista degli identificativi (URL) delle entità abilitate ad emetterli.
 
 I Trust Mark rappresentano il primo filtro per l'instaurazione della fiducia tra le parti, sono elementi indispensabili per avviare la risoluzione dei metadati. In loro assenza una entità non è riconoscibile come partecipante all’interno della Federazione.
 

--- a/docs/it/trust_negotiation.rst
+++ b/docs/it/trust_negotiation.rst
@@ -51,7 +51,7 @@ Ottenuto il Metadata finale, il Provider valida la richiesta del RP secondo le m
 Nei casi in cui un RP avesse come entità superiore un SA e non direttamente il TA, la procedura di acquisizione e validazione dell'Entity Configuration del RP avviene mediante l'Entity Statement pubblicato dal SA nei confronti del RP e mediante la convalida dell'Entity Configuration del SA con l'Entity Statement emesso dalla TA in relazione al SA. Se la soglia del massimo numero di Intermediari verticali, definita dal valore di **max_path_length**, viene superata, l'OP blocca il processo di Federation Entity Discovery e rigetta la richiesta del RP.
 
 
-.. [1] I Trust Mark di Federazione sono configurati nel claim **trust_marks_issuers** e contenuti nell'Entity Configuration del Trust Anchor.
+.. [1] I Trust Mark di Federazione sono configurati nel claim **trust_mark_issuers** e contenuti nell'Entity Configuration del Trust Anchor.
 
 .. [2] Un RP può esporre più di una entità superiore all'interno del proprio claim di **authority_hints**. Si pensi ad un RP che partecipa sia alla Federazione SPID che a quella CIE. Inoltre un RP può risultare come aggregato di molteplici Intermediari, sia questi SPID o CIE.
 

--- a/docs/it/userinfo_endpoint.rst
+++ b/docs/it/userinfo_endpoint.rst
@@ -17,7 +17,7 @@ Request
   Lo UserInfo Endpoint DEVE supportare l'uso dei metodi HTTP GET e POST :rfc:`2616` e DEVE accettare e validare l'Access Token inviato all'interno del campo Authorization dell'Header, di tipo Bearer :rfc:`6750`. 
 
 
-.. code-block::  http
+.. code-block::  
 
   GET https://op.spid.agid.gov.it/userinfo
   Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6ImRCNjdnTDdja ...


### PR DESCRIPTION
## Title
Fix typos

## Content
This PR: 
- Fix typo in AT related to aud claim
- Restores some required claims in the OP Metadata
- Fix metadata policy operators and values (fix non normative examples accordingly)
- Fix metadata policy in non-normative examples regarding the JWKS keys value
- Add client_id in the RT and clarifies the meaning of aud claim in the RT.
Moreover, this:
- closes #181
- closes #176 
- closes #179 

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [x] Example files 
- [x] Ask for review
