### PR TITLE
chore: fix acr_values field in Authorization Request example

### DIFF
--- a/docs/common/common_examples.rst
+++ b/docs/common/common_examples.rst
@@ -775,10 +775,7 @@ EN 6. Authorization Request
       "nonce": "MBzGqyf9QytD28eupyWhSqMj78WNqpc2",
       "prompt": "login",
       "redirect_uri": "https://rp.spid.agid.gov.it/callback1",
-      "acr_values": {
-        "https://www.spid.gov.it/SpidL1":null,
-        "https://www.spid.gov.it/SpidL2":null
-      },
+      "acr_values": "https://www.spid.gov.it/SpidL1 https://www.spid.gov.it/SpidL2",
       "claims": {
         "userinfo": {
             "given_name":null,


### PR DESCRIPTION
## Title

fix acr_values field in Authorization Request example

## Content

In the Authorization Request the claim [acr_values](https://github.com/italia/spid-cie-oidc-docs/blob/a65aa1a6ccc2bf03d8c18dd8df2ee22ec2613316/docs/common/common_examples.rst?plain=1#L778) is a json object but according to the [documentation](https://github.com/italia/spid-cie-oidc-docs/blob/a65aa1a6ccc2bf03d8c18dd8df2ee22ec2613316/docs/en/authorization_endpoint.rst?plain=1#L120) it should be a "[...] string with the requested "acr" values, each of them separated by a single space".

## Review

- [ ] Ensure your files are written following RST specs (*not MD!*)
- [ ] Italian version
- [ ] English version
- [x] Example files 
- [ ] Ask for review
