### PR TITLE
Fixes example of a TM issued from a TA to a RP

### DIFF
--- a/docs/common/common_examples.rst
+++ b/docs/common/common_examples.rst
@@ -422,7 +422,7 @@ Where the $JWT payload is:
 
  {
      "id": "https://registry.interno.gov.it/openid_relying_party/public/",
-     "iss": "https://sa.esempio.it/",
+     "iss": "https://registry.interno.gov.it/",
      "sub": "https://rp.esempio.it/",
      "iat": 1579621160,
      "organization_type": "public",

--- a/docs/en/trust_marks.rst
+++ b/docs/en/trust_marks.rst
@@ -223,9 +223,6 @@ The claims defined inside the TMs are compliant with the elements defined in the
     * - **organization_name**
       - String. The complete name of the service-supplying Entity.
       - |spid-icon| |cieid-icon|
-    * - **sa_profile**
-      - String. REQUIRED for SA. Specifies the Aggregator profile, **full** or **light**.
-      - |spid-icon| |cieid-icon|
 
 .. warning::
 

--- a/docs/en/trust_marks.rst
+++ b/docs/en/trust_marks.rst
@@ -223,6 +223,9 @@ The claims defined inside the TMs are compliant with the elements defined in the
     * - **organization_name**
       - String. The complete name of the service-supplying Entity.
       - |spid-icon| |cieid-icon|
+    * - **sa_profile**
+      - String. REQUIRED for SA. Specifies the Aggregator profile, **full** or **light**.
+      - |spid-icon| |cieid-icon|
 
 .. warning::
 


### PR DESCRIPTION
## Fixes example of a TM issued from a TA to a RP

## Content
- Just fixes the issuer _entity id_ on the **trust_mark**

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [ ] Italian version
- [ ] English version
- [x] Example files 
- [x] Ask for review
